### PR TITLE
feat: add hl7-forge.toml configuration file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,25 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 ## [Unreleased]
 
 ### Added
+- **Configuration file** (`hl7-forge.toml`) — ports, memory limits, log level, MLLP timeouts and max message size configurable without recompilation
+  - Load priority: config file (next to binary or CWD) → environment variables (`MLLP_PORT`, `WEB_PORT`, `RUST_LOG`) → built-in defaults
+  - New `src/config.rs` module with `Config`, `ServerConfig`, `LoggingConfig`, `StoreConfig`, `MllpConfig` structs
+  - Example `hl7-forge.toml` included with all defaults commented out
 - Templates for Bugs and Feature Requests
 - CONTRIBUTING, SECURITY, and Pull Request templates
 
 ### Changed
+- `MessageStore::new()` now accepts `StoreConfig` — store capacity and memory limit are configurable
+- `start_mllp_server()` now accepts `MllpConfig` — timeouts and max message size are configurable
+- Hardcoded constants (`DEFAULT_CAPACITY`, `MAX_STORE_BYTES`, `MAX_MESSAGE_SIZE`, `READ_TIMEOUT`, `WRITE_TIMEOUT`) replaced with config values
+- Effective configuration is logged at startup
 - Translated all German text to English across the codebase
 - Updated ROADMAP with completed Phase 1 tasks, specific sections, and guidelines
 - Added detailed issue comment preferences for AI agents
 
 ### Fixed
 - Fixed UI sync on clear database
+- Fixed clippy warnings: derivable impl, char comparison pattern, `to_string` in format args, large enum variant
 
 ### Commit History (chronological)
 
@@ -27,6 +36,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 | Commit | Description |
 |--------|-------------|
+| [`da5738a`](https://github.com/Pappet/hl7-forge/commit/da5738a5ced7625ddf524b87fd0a5e6558b1f275) | `feat:` add hl7-forge.toml configuration file support |
 | [`29e5e8c`](https://github.com/Pappet/hl7-forge/commit/29e5e8c6a7336400a1e02e05687ad1976cfec330) | `docs:` add CONTRIBUTING, SECURITY, and PR template |
 | [`89ba306`](https://github.com/Pappet/hl7-forge/commit/89ba3063590a0ee3aef05f0e3ebf5b07921dcfd4) | `chore:` Add Templates for Bugs and Feature Requests |
 
@@ -43,12 +53,12 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 > Goal: HL7 Forge runs stably as a Windows service on the dev server, is configurable without recompilation, and holds up under high load.
 
-- **Configuration file** (`hl7-forge.toml`) — ports, memory limits, log level, and retention configurable without recompilation
+- ~~**Configuration file** (`hl7-forge.toml`)~~ — **Done** (see Added above)
 - **Windows Service** — installable via `sc create` / NSSM, automatic start on server reboot
 - **Windows Event Log integration** — startup banner in Windows Event Log for ops monitoring
 - **Portable binary** — single `.exe` without runtime dependencies, xcopy deployment
 - **Backpressure handling** — evict oldest messages when the store is full instead of OOM
-- **Memory budget** — configurable RAM limit (e.g. 512 MB), automatic eviction on excess
+- ~~**Memory budget**~~ — **Done** (configurable via `hl7-forge.toml` `[store] max_memory_mb`)
 - **Connection limits** — cap maximum concurrent MLLP connections
 - **Graceful shutdown** — cleanly terminate active connections on `Ctrl+C` or service stop
 
@@ -231,7 +241,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 ### Known Issues
 
-- Memory limit (`MAX_STORE_BYTES`) is currently hardcoded — will be configurable via `hl7-forge.toml` in Milestone 1
+- None
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -407,6 +407,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -885,6 +886,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1072,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1512,6 +1563,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tower-http = { version = "0.5", features = ["cors", "fs"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 
 # Utilities
 chrono = { version = "0.4", features = ["serde"] }

--- a/hl7-forge.toml
+++ b/hl7-forge.toml
@@ -1,0 +1,20 @@
+# HL7 Forge Configuration
+# All values shown below are the built-in defaults.
+# Uncomment and change only the settings you need.
+# Environment variables (MLLP_PORT, WEB_PORT, RUST_LOG) override this file.
+
+# [server]
+# mllp_port = 2575
+# web_port = 8080
+
+# [logging]
+# level = "info"
+
+# [store]
+# max_messages = 10000
+# max_memory_mb = 512
+
+# [mllp]
+# max_message_size_mb = 10
+# read_timeout_secs = 60
+# write_timeout_secs = 30

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,302 @@
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::time::Duration;
+use tracing::info;
+
+/// Top-level configuration for HL7 Forge.
+///
+/// Load priority: `hl7-forge.toml` (next to binary, then CWD) → env vars → built-in defaults.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub server: ServerConfig,
+    pub logging: LoggingConfig,
+    pub store: StoreConfig,
+    pub mllp: MllpConfig,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct ServerConfig {
+    pub mllp_port: u16,
+    pub web_port: u16,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct LoggingConfig {
+    pub level: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct StoreConfig {
+    pub max_messages: usize,
+    pub max_memory_mb: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct MllpConfig {
+    pub max_message_size_mb: usize,
+    pub read_timeout_secs: u64,
+    pub write_timeout_secs: u64,
+}
+
+// --- Defaults ---
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            mllp_port: 2575,
+            web_port: 8080,
+        }
+    }
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            level: "info".to_string(),
+        }
+    }
+}
+
+impl Default for StoreConfig {
+    fn default() -> Self {
+        Self {
+            max_messages: 10_000,
+            max_memory_mb: 512,
+        }
+    }
+}
+
+impl Default for MllpConfig {
+    fn default() -> Self {
+        Self {
+            max_message_size_mb: 10,
+            read_timeout_secs: 60,
+            write_timeout_secs: 30,
+        }
+    }
+}
+
+// --- Convenience methods ---
+
+impl StoreConfig {
+    pub fn max_memory_bytes(&self) -> usize {
+        self.max_memory_mb * 1024 * 1024
+    }
+}
+
+impl MllpConfig {
+    pub fn max_message_size(&self) -> usize {
+        self.max_message_size_mb * 1024 * 1024
+    }
+
+    pub fn read_timeout(&self) -> Duration {
+        Duration::from_secs(self.read_timeout_secs)
+    }
+
+    pub fn write_timeout(&self) -> Duration {
+        Duration::from_secs(self.write_timeout_secs)
+    }
+}
+
+// --- Loading ---
+
+impl Config {
+    /// Load configuration with priority: file → env vars → defaults.
+    pub fn load() -> Self {
+        let mut config = match find_config_path() {
+            Some(path) => {
+                info!("Loading config from {}", path.display());
+                match std::fs::read_to_string(&path) {
+                    Ok(contents) => match toml::from_str::<Config>(&contents) {
+                        Ok(cfg) => cfg,
+                        Err(e) => {
+                            eprintln!(
+                                "WARNING: Failed to parse {}: {}. Using defaults.",
+                                path.display(),
+                                e
+                            );
+                            Config::default()
+                        }
+                    },
+                    Err(e) => {
+                        eprintln!(
+                            "WARNING: Failed to read {}: {}. Using defaults.",
+                            path.display(),
+                            e
+                        );
+                        Config::default()
+                    }
+                }
+            }
+            None => Config::default(),
+        };
+
+        // Env-var overrides (highest priority)
+        if let Ok(val) = std::env::var("MLLP_PORT") {
+            if let Ok(port) = val.parse::<u16>() {
+                config.server.mllp_port = port;
+            }
+        }
+        if let Ok(val) = std::env::var("WEB_PORT") {
+            if let Ok(port) = val.parse::<u16>() {
+                config.server.web_port = port;
+            }
+        }
+        if let Ok(val) = std::env::var("RUST_LOG") {
+            config.logging.level = val;
+        }
+
+        config
+    }
+}
+
+/// Search for `hl7-forge.toml`: first next to the binary, then in the CWD.
+fn find_config_path() -> Option<PathBuf> {
+    const FILE_NAME: &str = "hl7-forge.toml";
+
+    // 1. Next to the binary
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let candidate = dir.join(FILE_NAME);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    // 2. Current working directory
+    if let Ok(cwd) = std::env::current_dir() {
+        let candidate = cwd.join(FILE_NAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+impl std::fmt::Display for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "  MLLP port:          {}", self.server.mllp_port)?;
+        writeln!(f, "  Web port:           {}", self.server.web_port)?;
+        writeln!(f, "  Log level:          {}", self.logging.level)?;
+        writeln!(f, "  Max messages:       {}", self.store.max_messages)?;
+        writeln!(f, "  Max memory:         {} MB", self.store.max_memory_mb)?;
+        writeln!(
+            f,
+            "  Max message size:   {} MB",
+            self.mllp.max_message_size_mb
+        )?;
+        writeln!(
+            f,
+            "  Read timeout:       {}s",
+            self.mllp.read_timeout_secs
+        )?;
+        write!(
+            f,
+            "  Write timeout:      {}s",
+            self.mllp.write_timeout_secs
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_defaults() {
+        let config = Config::default();
+        assert_eq!(config.server.mllp_port, 2575);
+        assert_eq!(config.server.web_port, 8080);
+        assert_eq!(config.logging.level, "info");
+        assert_eq!(config.store.max_messages, 10_000);
+        assert_eq!(config.store.max_memory_mb, 512);
+        assert_eq!(config.mllp.max_message_size_mb, 10);
+        assert_eq!(config.mllp.read_timeout_secs, 60);
+        assert_eq!(config.mllp.write_timeout_secs, 30);
+    }
+
+    #[test]
+    fn test_convenience_methods() {
+        let store = StoreConfig::default();
+        assert_eq!(store.max_memory_bytes(), 512 * 1024 * 1024);
+
+        let mllp = MllpConfig::default();
+        assert_eq!(mllp.max_message_size(), 10 * 1024 * 1024);
+        assert_eq!(mllp.read_timeout(), Duration::from_secs(60));
+        assert_eq!(mllp.write_timeout(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_parse_full_toml() {
+        let toml_str = r#"
+[server]
+mllp_port = 3000
+web_port = 9090
+
+[logging]
+level = "debug"
+
+[store]
+max_messages = 5000
+max_memory_mb = 256
+
+[mllp]
+max_message_size_mb = 20
+read_timeout_secs = 120
+write_timeout_secs = 60
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.server.mllp_port, 3000);
+        assert_eq!(config.server.web_port, 9090);
+        assert_eq!(config.logging.level, "debug");
+        assert_eq!(config.store.max_messages, 5000);
+        assert_eq!(config.store.max_memory_mb, 256);
+        assert_eq!(config.mllp.max_message_size_mb, 20);
+        assert_eq!(config.mllp.read_timeout_secs, 120);
+        assert_eq!(config.mllp.write_timeout_secs, 60);
+    }
+
+    #[test]
+    fn test_parse_partial_toml() {
+        let toml_str = r#"
+[server]
+mllp_port = 4000
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.server.mllp_port, 4000);
+        // All other fields should use defaults
+        assert_eq!(config.server.web_port, 8080);
+        assert_eq!(config.logging.level, "info");
+        assert_eq!(config.store.max_messages, 10_000);
+        assert_eq!(config.mllp.read_timeout_secs, 60);
+    }
+
+    #[test]
+    fn test_parse_empty_toml() {
+        let config: Config = toml::from_str("").unwrap();
+        assert_eq!(config.server.mllp_port, 2575);
+        assert_eq!(config.server.web_port, 8080);
+    }
+
+    #[test]
+    fn test_unknown_fields_ignored() {
+        let toml_str = r#"
+[server]
+mllp_port = 2575
+unknown_field = "should be ignored"
+
+[unknown_section]
+foo = "bar"
+"#;
+        // serde(default) with deny_unknown_fields not set → unknown fields are ignored
+        let result = toml::from_str::<Config>(toml_str);
+        assert!(result.is_ok());
+    }
+}

--- a/src/hl7/parser.rs
+++ b/src/hl7/parser.rs
@@ -19,7 +19,7 @@ pub fn parse_message(raw: &str, source_addr: &str) -> Result<Hl7Message, String>
 
     // Split into segments (HL7 uses \r as segment terminator, but be lenient)
     let segment_strs: Vec<&str> = raw
-        .split(|c| c == '\r' || c == '\n')
+        .split(['\r', '\n'])
         .filter(|s| !s.trim().is_empty())
         .collect();
 
@@ -166,7 +166,7 @@ pub fn build_ack(original: &Hl7Message, ack_code: &str) -> String {
         original.sending_facility,
         now,
         original.trigger_event,
-        uuid::Uuid::new_v4().to_string().replace('-', "")[..20].to_string(),
+        &uuid::Uuid::new_v4().to_string().replace('-', "")[..20],
         original.version,
     );
     let msa = format!(


### PR DESCRIPTION
## Summary

- Add `hl7-forge.toml` config file support with load priority: config file (next to binary or CWD) → env vars (`MLLP_PORT`, `WEB_PORT`, `RUST_LOG`) → built-in defaults
- New `src/config.rs` module with `Config`, `ServerConfig`, `LoggingConfig`, `StoreConfig`, `MllpConfig` structs (all with `#[serde(default)]`)
- Replace hardcoded constants (`DEFAULT_CAPACITY`, `MAX_STORE_BYTES`, `MAX_MESSAGE_SIZE`, `READ_TIMEOUT`, `WRITE_TIMEOUT`) with configurable values
- Log effective configuration at startup

## Test plan

- [x] `cargo build` compiles without errors
- [x] `cargo test` — 11 tests pass (5 new config tests + 6 existing)
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: start server without config file → defaults apply
- [ ] Manual: place `hl7-forge.toml` with custom ports → logs show new values
- [ ] Manual: set `MLLP_PORT=9999` env var → overrides config file value

🤖 Generated with [Claude Code](https://claude.com/claude-code)