### PR TITLE
test: Add regression tests for MSH field indexing quirk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - GitHub Actions CI workflow (`.github/workflows/ci.yml`) for `fmt`, `clippy`, `build`, and `test`
 - Templates for Bugs and Feature Requests
 - CONTRIBUTING, SECURITY, and Pull Request templates
+- **Tests**: Add regression test for MSH field indexing quirk (#11)
 
 ### Changed
 - `MessageStore::new()` now accepts `StoreConfig` — store capacity and memory limit are configurable
@@ -34,6 +35,12 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - Fixed clippy warnings: derivable impl, char comparison pattern, `to_string` in format args, large enum variant
 
 ### Commit History (chronological)
+
+#### 2026-03-05
+
+| Commit | Description |
+|--------|-------------|
+| [`16d4da8`](https://github.com/Pappet/hl7-forge/commit/16d4da82c54484485c7af0d56d00cef1f78e7b49) | `test:` Add regression tests for MSH field indexing quirk (#11) |
 
 #### 2026-02-28
 

--- a/src/hl7/parser.rs
+++ b/src/hl7/parser.rs
@@ -219,4 +219,16 @@ mod tests {
         assert!(ack.starts_with("MSH|^~\\&|HL7Forge"));
         assert!(ack.contains("MSA|AA|MSG00001"));
     }
+
+    #[test]
+    fn test_msh_field_indexing_quirk() {
+        let msg = parse_message(SAMPLE_ADT, "127.0.0.1:9999").unwrap();
+        let msh = msg.segments.first().unwrap();
+        assert_eq!(msh.name, "MSH");
+        assert_eq!(get_field_value(msh, 1), "|");
+        assert_eq!(get_field_value(msh, 2), "^~\\&");
+        assert_eq!(get_field_value(msh, 3), "SENDING_APP");
+        assert_eq!(get_field_value(msh, 4), "SENDING_FAC");
+        assert_eq!(get_field_value(msh, 9), "ADT^A01^ADT_A01");
+    }
 }


### PR DESCRIPTION
Fixes #11. Added a test to verify the MSH indexing quirk where MSH-1 acts as the field separator, causing subsequent indices to be shifted.