### PR TITLE
feat: Connection limits for MLLP server (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 ## [Unreleased]
 
 ### Added
+- **Connection limits** — configurable `max_connections` (default 100) for the MLLP server using a `tokio::sync::Semaphore`; rejected connections are counted and exposed via `/api/stats` (#6)
 - **ACK UI**: Sent ACK/NACK messages (AA, AE, AR) are now stored and viewable in an "ACK" tab (#19)
 - **Graceful shutdown** — MLLP server active connections are cleanly drained on `Ctrl+C` or service stop before exiting (#7)
 - **Configuration file** (`hl7-forge.toml`) — ports, memory limits, log level, MLLP timeouts and max message size configurable without recompilation
@@ -86,7 +87,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - ~~**Portable binary**~~ — **Done** (single `.exe` without runtime dependencies, xcopy deployment)
 - ~~**Backpressure handling**~~ — **Done** (evict oldest messages when the store is full instead of OOM)
 - ~~**Memory budget**~~ — **Done** (configurable via `hl7-forge.toml` `[store] max_memory_mb`)
-- **Connection limits** — cap maximum concurrent MLLP connections
+- ~~**Connection limits**~~ — **Done** (configurable `max_connections`, see Added above)
 - ~~**Graceful shutdown**~~ — **Done** (see Added above)
 
 ### Planned – Milestone 2: Multi-User Experience

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Designed as a drop-in replacement for HL7 Inspector: runs as a central service, 
 | 🔎 **Search & Filter** | By message type, patient name, facility, message control ID, source IP |
 | 💾 **Smart Store** | In-memory, 100k message capacity with automatic 10% eviction |
 | 📥 **JSON Export** | Export full message list with one click |
-| 🛡️ **Hardened** | 10 MB payload cap, 60s read timeout, graceful shutdown on `Ctrl+C` |
+| 🛡️ **Hardened** | 10 MB payload cap, 60s read timeout, configurable connection limits, graceful shutdown |
 | 📦 **Single Binary** | Frontend embedded via `rust-embed` — zero runtime dependencies |
 
 ---

--- a/hl7-forge.toml
+++ b/hl7-forge.toml
@@ -21,3 +21,4 @@
 # max_message_size_mb = 10
 # read_timeout_secs = 60
 # write_timeout_secs = 30
+# max_connections = 100

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,7 @@ pub struct MllpConfig {
     pub max_message_size_mb: usize,
     pub read_timeout_secs: u64,
     pub write_timeout_secs: u64,
+    pub max_connections: usize,
 }
 
 // --- Defaults ---
@@ -85,6 +86,7 @@ impl Default for MllpConfig {
             max_message_size_mb: 10,
             read_timeout_secs: 60,
             write_timeout_secs: 30,
+            max_connections: 100,
         }
     }
 }
@@ -215,7 +217,8 @@ impl std::fmt::Display for Config {
             self.mllp.max_message_size_mb
         )?;
         writeln!(f, "  Read timeout:       {}s", self.mllp.read_timeout_secs)?;
-        write!(f, "  Write timeout:      {}s", self.mllp.write_timeout_secs)
+        writeln!(f, "  Write timeout:      {}s", self.mllp.write_timeout_secs)?;
+        write!(f, "  Max connections:    {}", self.mllp.max_connections)
     }
 }
 
@@ -238,6 +241,7 @@ mod tests {
         assert_eq!(config.mllp.max_message_size_mb, 10);
         assert_eq!(config.mllp.read_timeout_secs, 60);
         assert_eq!(config.mllp.write_timeout_secs, 30);
+        assert_eq!(config.mllp.max_connections, 100);
     }
 
     #[test]
@@ -273,6 +277,7 @@ max_memory_mb = 256
 max_message_size_mb = 20
 read_timeout_secs = 120
 write_timeout_secs = 60
+max_connections = 50
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.server.mllp_port, 3000);
@@ -287,6 +292,7 @@ write_timeout_secs = 60
         assert_eq!(config.mllp.max_message_size_mb, 20);
         assert_eq!(config.mllp.read_timeout_secs, 120);
         assert_eq!(config.mllp.write_timeout_secs, 60);
+        assert_eq!(config.mllp.max_connections, 50);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,7 @@ async fn main() -> anyhow::Result<()> {
         store: store.clone(),
         stats: stats.clone(),
         mllp_port,
+        max_connections: config.mllp.max_connections,
     };
     let app = create_router(app_state);
     let web_addr = format!("0.0.0.0:{}", web_port);

--- a/src/mllp.rs
+++ b/src/mllp.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::watch;
+use tokio::sync::Semaphore;
 use tokio::time::timeout;
 use tracing::{debug, info, warn};
 
@@ -22,6 +23,7 @@ pub struct MllpStats {
     pub parsed_ok: Arc<AtomicU64>,
     pub parse_errors: Arc<AtomicU64>,
     pub active_connections: Arc<AtomicU64>,
+    pub rejected_connections: Arc<AtomicU64>,
 }
 
 impl MllpStats {
@@ -31,6 +33,7 @@ impl MllpStats {
             parsed_ok: Arc::new(AtomicU64::new(0)),
             parse_errors: Arc::new(AtomicU64::new(0)),
             active_connections: Arc::new(AtomicU64::new(0)),
+            rejected_connections: Arc::new(AtomicU64::new(0)),
         }
     }
 }
@@ -43,9 +46,14 @@ pub async fn start_mllp_server(
     mut shutdown: watch::Receiver<bool>,
     config: MllpConfig,
 ) -> anyhow::Result<()> {
+    let max_connections = config.max_connections;
+    let semaphore = Arc::new(Semaphore::new(max_connections));
     let config = Arc::new(config);
     let listener = TcpListener::bind(bind_addr).await?;
-    info!("MLLP server listening on {}", bind_addr);
+    info!(
+        "MLLP server listening on {} (max {} connections)",
+        bind_addr, max_connections
+    );
 
     loop {
         tokio::select! {
@@ -62,16 +70,31 @@ pub async fn start_mllp_server(
                 let peer = peer_addr.to_string();
                 let shutdown_clone = shutdown.clone();
 
-                stats.active_connections.fetch_add(1, Ordering::Relaxed);
-                info!("New MLLP connection from {}", peer);
+                // Try to acquire a connection permit
+                match Arc::clone(&semaphore).try_acquire_owned() {
+                    Ok(permit) => {
+                        stats.active_connections.fetch_add(1, Ordering::Relaxed);
+                        info!("New MLLP connection from {}", peer);
 
-                tokio::spawn(async move {
-                    if let Err(e) = handle_connection(socket, &peer, &store, &stats, &config, shutdown_clone).await {
-                        warn!("Connection error from {}: {}", peer, e);
+                        tokio::spawn(async move {
+                            if let Err(e) = handle_connection(socket, &peer, &store, &stats, &config, shutdown_clone).await {
+                                warn!("Connection error from {}: {}", peer, e);
+                            }
+                            stats.active_connections.fetch_sub(1, Ordering::Relaxed);
+                            info!("MLLP connection closed: {}", peer);
+                            drop(permit); // Release the semaphore permit
+                        });
                     }
-                    stats.active_connections.fetch_sub(1, Ordering::Relaxed);
-                    info!("MLLP connection closed: {}", peer);
-                });
+                    Err(_) => {
+                        stats.rejected_connections.fetch_add(1, Ordering::Relaxed);
+                        warn!(
+                            "Connection from {} rejected: max connections ({}) reached",
+                            peer, max_connections
+                        );
+                        // Socket is dropped here, closing the TCP connection
+                        drop(socket);
+                    }
+                }
             }
         }
     }
@@ -253,5 +276,15 @@ mod tests {
         assert_eq!(wrapped[0], MLLP_START);
         assert_eq!(wrapped[wrapped.len() - 2], MLLP_END_1);
         assert_eq!(wrapped[wrapped.len() - 1], MLLP_END_2);
+    }
+
+    #[test]
+    fn test_mllp_stats_new() {
+        let stats = MllpStats::new();
+        assert_eq!(stats.received.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.parsed_ok.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.parse_errors.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.active_connections.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.rejected_connections.load(Ordering::Relaxed), 0);
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -19,6 +19,7 @@ pub struct AppState {
     pub store: MessageStore,
     pub stats: MllpStats,
     pub mllp_port: u16,
+    pub max_connections: usize,
 }
 
 pub fn create_router(state: AppState) -> Router {
@@ -84,6 +85,8 @@ async fn get_stats(State(state): State<AppState>) -> impl IntoResponse {
         "parsed_ok": state.stats.parsed_ok.load(Ordering::Relaxed),
         "parse_errors": state.stats.parse_errors.load(Ordering::Relaxed),
         "active_connections": state.stats.active_connections.load(Ordering::Relaxed),
+        "rejected_connections": state.stats.rejected_connections.load(Ordering::Relaxed),
+        "max_connections": state.max_connections,
         "mllp_port": state.mllp_port,
     }))
 }

--- a/static/app.js
+++ b/static/app.js
@@ -108,8 +108,18 @@ async function pollStats() {
         if (!resp.ok) return;
         const stats = await resp.json();
         document.getElementById('stat-total').textContent = stats.total_messages;
-        document.getElementById('stat-connections').textContent = stats.active_connections;
+        document.getElementById('stat-connections').textContent =
+            `${stats.active_connections} / ${stats.max_connections}`;
         document.getElementById('stat-errors').textContent = stats.parse_errors;
+        const rejectedEl = document.getElementById('stat-rejected');
+        if (rejectedEl) {
+            if (stats.rejected_connections > 0) {
+                rejectedEl.parentElement.style.display = '';
+                rejectedEl.textContent = stats.rejected_connections;
+            } else {
+                rejectedEl.parentElement.style.display = 'none';
+            }
+        }
         if (stats.mllp_port) {
             document.getElementById('mllp-port').textContent = stats.mllp_port;
         }

--- a/static/index.html
+++ b/static/index.html
@@ -1,23 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HL7 Forge</title>
     <link rel="stylesheet" href="/style.css">
 </head>
+
 <body>
     <header>
         <div class="logo">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" fill="var(--accent)" stroke="var(--accent)"/>
+                <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" fill="var(--accent)" stroke="var(--accent)" />
             </svg>
             HL7 Forge
         </div>
         <div class="stats-bar">
-            <div class="stat"><span class="stat-dot green" id="ws-dot"></span><span id="ws-status">Connecting...</span></div>
+            <div class="stat"><span class="stat-dot green" id="ws-dot"></span><span id="ws-status">Connecting...</span>
+            </div>
             <div class="stat"><span class="stat-dot blue"></span>Messages: <span id="stat-total">0</span></div>
-            <div class="stat"><span class="stat-dot yellow"></span>Connections: <span id="stat-connections">0</span></div>
+            <div class="stat"><span class="stat-dot yellow"></span>Connections: <span id="stat-connections">0</span>
+            </div>
+            <div class="stat" style="display:none"><span class="stat-dot"
+                    style="background:var(--warning)"></span>Rejected: <span id="stat-rejected">0</span></div>
             <div class="stat"><span class="stat-dot red"></span>Errors: <span id="stat-errors">0</span></div>
         </div>
         <div class="header-actions">
@@ -44,7 +50,7 @@
             <div class="message-list" id="message-list">
                 <div class="empty-state" id="empty-state">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
+                        <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
                     </svg>
                     <p>Waiting for HL7 messages...</p>
                     <span class="hint">MLLP Server listening on port <span id="mllp-port">2575</span></span>
@@ -55,7 +61,8 @@
         <div class="detail-panel">
             <div class="detail-header">
                 <h2 id="detail-title">Select a message</h2>
-                <span id="detail-meta" style="font-size: 11px; color: var(--text-muted); font-family: var(--font-mono);"></span>
+                <span id="detail-meta"
+                    style="font-size: 11px; color: var(--text-muted); font-family: var(--font-mono);"></span>
             </div>
             <div class="detail-tabs">
                 <button class="detail-tab active" data-tab="parsed" onclick="switchTab('parsed')">Segments</button>
@@ -73,4 +80,5 @@
 
     <script src="/app.js" defer></script>
 </body>
+
 </html>


### PR DESCRIPTION
## Summary

Adds a configurable maximum concurrent connection limit to the MLLP server, closing #6.

## Changes

- **Config**: Added `max_connections` (default: 100) to `MllpConfig`
- **MLLP Server**: Uses `tokio::sync::Semaphore` to enforce connection limits; tracks rejected connections
- **API**: `/api/stats` now includes `max_connections` and `rejected_connections`
- **Web UI**: Connections displayed as `active / max`; rejected count shown when > 0
- **Docs**: Updated CHANGELOG.md and README.md

## Verification

- All 13 tests pass (12 existing + 1 new `test_mllp_stats_new`)
- `cargo clippy -- -D warnings` clean
- Verify MCP contract passed (6/6 checks)

Closes #6