### PR TITLE
feat: add resizable panel splitter between message list and detail view (#4)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -58,6 +58,8 @@
             </div>
         </div>
 
+        <div class="panel-splitter" id="panel-splitter" title="Drag to resize, double-click to reset"></div>
+
         <div class="detail-panel">
             <div class="detail-header">
                 <h2 id="detail-title">Select a message</h2>

--- a/static/style.css
+++ b/static/style.css
@@ -16,7 +16,11 @@
     --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
 }
 
-* { margin: 0; padding: 0; box-sizing: border-box; }
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
 
 body {
     font-family: var(--font-sans);
@@ -49,7 +53,10 @@ header {
     letter-spacing: -0.3px;
 }
 
-.logo svg { width: 22px; height: 22px; }
+.logo svg {
+    width: 22px;
+    height: 22px;
+}
 
 .stats-bar {
     display: flex;
@@ -59,17 +66,40 @@ header {
     color: var(--text-secondary);
 }
 
-.stat { display: flex; align-items: center; gap: 6px; }
+.stat {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .stat-dot {
-    width: 7px; height: 7px; border-radius: 50%;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
     display: inline-block;
 }
-.stat-dot.green { background: var(--success); box-shadow: 0 0 6px var(--success); }
-.stat-dot.blue { background: var(--accent); }
-.stat-dot.red { background: var(--error); }
-.stat-dot.yellow { background: var(--warning); }
 
-.header-actions { display: flex; gap: 8px; }
+.stat-dot.green {
+    background: var(--success);
+    box-shadow: 0 0 6px var(--success);
+}
+
+.stat-dot.blue {
+    background: var(--accent);
+}
+
+.stat-dot.red {
+    background: var(--error);
+}
+
+.stat-dot.yellow {
+    background: var(--warning);
+}
+
+.header-actions {
+    display: flex;
+    gap: 8px;
+}
 
 button {
     background: var(--bg-tertiary);
@@ -82,9 +112,19 @@ button {
     transition: background 0.15s;
     font-family: var(--font-sans);
 }
-button:hover { background: var(--bg-hover); }
-button.danger { border-color: var(--error); color: var(--error); }
-button.danger:hover { background: rgba(224, 84, 84, 0.1); }
+
+button:hover {
+    background: var(--bg-hover);
+}
+
+button.danger {
+    border-color: var(--error);
+    color: var(--error);
+}
+
+button.danger:hover {
+    background: rgba(224, 84, 84, 0.1);
+}
 
 /* Main layout */
 .main-container {
@@ -95,11 +135,60 @@ button.danger:hover { background: rgba(224, 84, 84, 0.1); }
 
 /* Message list panel */
 .list-panel {
-    width: 55%;
-    min-width: 400px;
+    flex: 0 0 55%;
+    min-width: 300px;
     display: flex;
     flex-direction: column;
+}
+
+/* Panel splitter (drag handle) */
+.panel-splitter {
+    flex: 0 0 6px;
+    background: var(--bg-secondary);
+    cursor: col-resize;
+    position: relative;
+    border-left: 1px solid var(--border);
     border-right: 1px solid var(--border);
+    transition: background 0.15s;
+    z-index: 10;
+}
+
+.panel-splitter::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 2px;
+    height: 32px;
+    background: var(--text-muted);
+    border-radius: 1px;
+    opacity: 0.4;
+    transition: opacity 0.15s, height 0.15s;
+}
+
+.panel-splitter:hover {
+    background: var(--bg-tertiary);
+}
+
+.panel-splitter:hover::after {
+    opacity: 0.8;
+    height: 48px;
+    background: var(--accent);
+}
+
+.panel-splitter:active::after {
+    opacity: 1;
+    background: var(--accent);
+}
+
+body.resizing {
+    cursor: col-resize !important;
+    user-select: none !important;
+}
+
+body.resizing * {
+    cursor: col-resize !important;
 }
 
 .search-bar {
@@ -119,8 +208,14 @@ button.danger:hover { background: rgba(224, 84, 84, 0.1); }
     font-family: var(--font-mono);
     outline: none;
 }
-.search-bar input:focus { border-color: var(--accent); }
-.search-bar input::placeholder { color: var(--text-muted); }
+
+.search-bar input:focus {
+    border-color: var(--accent);
+}
+
+.search-bar input::placeholder {
+    color: var(--text-muted);
+}
 
 .message-list {
     flex: 1;
@@ -140,15 +235,28 @@ button.danger:hover { background: rgba(224, 84, 84, 0.1); }
     transition: background 0.1s;
     align-items: center;
 }
-.message-row:hover { background: var(--bg-hover); }
-.message-row.selected { background: var(--bg-tertiary); border-left: 3px solid var(--accent); }
+
+.message-row:hover {
+    background: var(--bg-hover);
+}
+
+.message-row.selected {
+    background: var(--bg-tertiary);
+    border-left: 3px solid var(--accent);
+}
+
 .message-row.new-flash {
     animation: flash 0.6s ease-out;
 }
 
 @keyframes flash {
-    0% { background: rgba(108, 140, 255, 0.15); }
-    100% { background: transparent; }
+    0% {
+        background: rgba(108, 140, 255, 0.15);
+    }
+
+    100% {
+        background: transparent;
+    }
 }
 
 .msg-type {
@@ -157,10 +265,32 @@ button.danger:hover { background: rgba(224, 84, 84, 0.1); }
     color: var(--accent);
 }
 
-.msg-source { color: var(--text-secondary); font-family: var(--font-mono); font-size: 11px; }
-.msg-patient { color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.msg-time { color: var(--text-muted); font-family: var(--font-mono); font-size: 11px; text-align: right; }
-.msg-segs { color: var(--text-muted); font-family: var(--font-mono); font-size: 11px; text-align: right; }
+.msg-source {
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 11px;
+}
+
+.msg-patient {
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.msg-time {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-align: right;
+}
+
+.msg-segs {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-align: right;
+}
 
 .list-header {
     display: grid;
@@ -185,9 +315,21 @@ button.danger:hover { background: rgba(224, 84, 84, 0.1); }
     color: var(--text-muted);
     gap: 12px;
 }
-.empty-state svg { width: 48px; height: 48px; opacity: 0.3; }
-.empty-state p { font-size: 14px; }
-.empty-state .hint { font-size: 12px; font-family: var(--font-mono); }
+
+.empty-state svg {
+    width: 48px;
+    height: 48px;
+    opacity: 0.3;
+}
+
+.empty-state p {
+    font-size: 14px;
+}
+
+.empty-state .hint {
+    font-size: 12px;
+    font-family: var(--font-mono);
+}
 
 /* Detail panel */
 .detail-panel {
@@ -232,8 +374,15 @@ button.danger:hover { background: rgba(224, 84, 84, 0.1); }
     border-left: none;
     border-right: none;
 }
-.detail-tab:hover { color: var(--text-primary); }
-.detail-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+.detail-tab:hover {
+    color: var(--text-primary);
+}
+
+.detail-tab.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+}
 
 .detail-content {
     flex: 1;
@@ -261,12 +410,17 @@ button.danger:hover { background: rgba(224, 84, 84, 0.1); }
     align-items: center;
     gap: 6px;
 }
-.segment-name:hover { color: var(--text-primary); }
+
+.segment-name:hover {
+    color: var(--text-primary);
+}
+
 .segment-name .collapse-icon {
     font-size: 10px;
     width: 12px;
     display: inline-block;
 }
+
 .segment-name .field-count {
     font-size: 10px;
     font-weight: 400;
@@ -364,13 +518,34 @@ button.danger:hover { background: rgba(224, 84, 84, 0.1); }
     z-index: 1000;
     animation: toast-in 0.2s ease-out;
 }
-.toast.error { border-color: var(--error); color: var(--error); }
+
+.toast.error {
+    border-color: var(--error);
+    color: var(--error);
+}
+
 @keyframes toast-in {
-    from { opacity: 0; transform: translateY(8px); }
-    to   { opacity: 1; transform: translateY(0); }
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 /* Scrollbar */
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--bg-tertiary); border-radius: 3px; }
+::-webkit-scrollbar {
+    width: 6px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--bg-tertiary);
+    border-radius: 3px;
+}


### PR DESCRIPTION
## Summary

Adds a draggable panel splitter between the message list and detail panels, allowing users to dynamically resize the two sections.

## Changes

- **index.html**: Added `<div class="panel-splitter">` element between the list and detail panels
- **style.css**: Added splitter styles (6px drag handle with hover/active states, body.resizing cursor override), changed `.list-panel` from fixed `width: 55%` to `flex: 0 0 55%`
- **app.js**: Added `initSplitter()` with full mouse/touch drag support, localStorage persistence (`hl7forge_splitter_width`), and double-click to reset
- **CHANGELOG.md**: Added entry under \[Unreleased\]

## Features

- **Drag to resize**: Grab the divider and drag left/right (mouse or touch)
- **Visual feedback**: Accent-colored grip indicator on hover, global col-resize cursor during drag
- **Persistence**: Panel width saved to localStorage, restored on reload
- **Double-click reset**: Returns to the default 55%/45% split
- **Clamped range**: Min 300px, max 80% of viewport width

Closes #4