### PR TITLE
feat: Implement exponential backoff for WebSocket reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 ## [Unreleased]
 
 ### Added
+- **WebSocket exponential backoff** — reconnection uses exponential backoff (1s → 2s → 4s → … → 60s cap) with ±25% jitter to prevent thundering herd; status bar shows reconnection countdown (#12)
 - **Resizable panel splitter** — drag the border between message list and detail panel to resize; double-click to reset; width persists across sessions via localStorage (#4)
 - **Color-coded source markers** — messages in the list show a colored dot mapped by source IP address (with an optional "Color by Port" toggle), along with a source legend for quick identification (#25)
 - **Session-based views** — each developer sees their own filter configuration, active tab, and scroll position independent of other users via `sessionStorage` (#24)

--- a/static/app.js
+++ b/static/app.js
@@ -8,6 +8,12 @@ let searchQuery = '';
 let ws = null;
 let collapsedSegments = new Set();
 
+// WebSocket reconnection with exponential backoff
+const WS_RECONNECT_INITIAL = 1000;   // 1 second
+const WS_RECONNECT_MAX = 60000;  // 60 seconds
+const WS_RECONNECT_MULT = 2;      // double each time
+let wsReconnectDelay = WS_RECONNECT_INITIAL;
+
 // Task 2: batching state
 let paused = false;
 let pendingMessages = [];
@@ -108,14 +114,18 @@ function connectWs() {
     ws = new WebSocket(`${proto}//${location.host}/ws`);
 
     ws.onopen = () => {
+        wsReconnectDelay = WS_RECONNECT_INITIAL; // reset on success
         document.getElementById('ws-dot').className = 'stat-dot green';
         document.getElementById('ws-status').textContent = 'Connected';
     };
 
     ws.onclose = () => {
         document.getElementById('ws-dot').className = 'stat-dot red';
-        document.getElementById('ws-status').textContent = 'Disconnected';
-        setTimeout(connectWs, 2000);
+        const jitter = wsReconnectDelay * (0.75 + Math.random() * 0.5);
+        const delaySec = Math.round(jitter / 1000);
+        document.getElementById('ws-status').textContent = `Reconnecting in ${delaySec}s\u2026`;
+        setTimeout(connectWs, jitter);
+        wsReconnectDelay = Math.min(wsReconnectDelay * WS_RECONNECT_MULT, WS_RECONNECT_MAX);
     };
 
     ws.onerror = (event) => {


### PR DESCRIPTION
## Summary

Replace the fixed 2-second WebSocket reconnection delay with exponential backoff to reduce server pressure during outages and prevent thundering herd on restart.

### Changes
- **Backoff constants**: `WS_RECONNECT_INITIAL=1000`, `WS_RECONNECT_MAX=60000`, `WS_RECONNECT_MULT=2`
- **Jitter**: ±25% randomization to spread out simultaneous client reconnections
- **UI countdown**: Status bar shows `Reconnecting in Ns…` instead of static 'Disconnected'
- **Auto-reset**: Delay resets to 1s on successful `ws.onopen`

### Result
~88% fewer failed connection attempts during extended outages (7 attempts in 2 minutes vs 60), while still recovering within 1s for brief disconnections.

Closes #12