### PR TITLE
feat: Bookmark/pin messages with eviction protection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,19 @@ HL7 Forge is a single-binary MLLP server with an embedded real-time web UI for i
 
 ---
 
+## Git Workflow — Branch + PR Required
+
+**Never commit directly to `main` or to an unrelated branch.** For every task:
+
+1. **Create a feature branch** from `main` with a descriptive name (e.g., `feat/bookmark-messages`, `fix/eviction-bug`).
+2. **Make all commits on that branch.**
+3. **Create a Pull Request** to `main` using `gh pr create` when the work is complete and all checks pass.
+4. Include the related issue number in the PR body (e.g., `Closes #27`).
+
+Do not push changes without a dedicated branch and PR — even for small fixes.
+
+---
+
 ## Build & Verification
 
 Always verify your changes compile and pass tests before considering a task complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 ## [Unreleased]
 
 ### Added
+- **Bookmark/pin messages** — star icon (★/☆) on each message row to bookmark important messages; "★ Bookmarks" filter button in header; bookmarked messages are protected from eviction; state syncs across tabs via WebSocket (#27)
 - **Message tagging** — manual tagging of messages for attribution (e.g., "Bug #1234"); tags filterable via search and synchronized across clients (#26)
 - **WebSocket exponential backoff** — reconnection uses exponential backoff (1s → 2s → 4s → … → 60s cap) with ±25% jitter to prevent thundering herd; status bar shows reconnection countdown (#12)
 - **Resizable panel splitter** — drag the border between message list and detail panel to resize; double-click to reset; width persists across sessions via localStorage (#4)
@@ -44,6 +45,12 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - Fixed clippy warnings: derivable impl, char comparison pattern, `to_string` in format args, large enum variant
 
 ### Commit History (chronological)
+
+#### 2026-03-07
+
+| Commit | Description |
+|--------|-------------|
+| [`5cc749f`](https://github.com/Pappet/hl7-forge/commit/5cc749fe76e9f29c6827d888b702ff09dba61e0c) | `feat:` Bookmark/pin messages with eviction protection (#27) |
 
 #### 2026-03-06
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,17 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Git Workflow — Branch + PR Required
+
+**Never commit directly to `main` or to an unrelated branch.** For every task:
+
+1. **Create a feature branch** from `main` with a descriptive name (e.g., `feat/bookmark-messages`, `fix/eviction-bug`).
+2. **Make all commits on that branch.**
+3. **Create a Pull Request** to `main` using `gh pr create` when the work is complete and all checks pass.
+4. Include the related issue number in the PR body (e.g., `Closes #27`).
+
+Do not push changes without a dedicated branch and PR — even for small fixes.
+
 ## Build & Run Commands
 
 ```bash

--- a/src/hl7/types.rs
+++ b/src/hl7/types.rs
@@ -24,6 +24,7 @@ pub struct Hl7Message {
     pub ack_response: Option<String>,
     pub ack_code: Option<String>,
     pub tags: Vec<String>,
+    pub bookmarked: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -84,6 +85,7 @@ impl Hl7Message {
             ack_response: None,
             ack_code: None,
             tags: Vec::new(),
+            bookmarked: false,
         }
     }
 }
@@ -105,6 +107,7 @@ pub struct Hl7MessageSummary {
     pub ack_response: Option<String>,
     pub ack_code: Option<String>,
     pub tags: Vec<String>,
+    pub bookmarked: bool,
 }
 
 impl From<&Hl7Message> for Hl7MessageSummary {
@@ -124,6 +127,7 @@ impl From<&Hl7Message> for Hl7MessageSummary {
             ack_response: msg.ack_response.clone(),
             ack_code: msg.ack_code.clone(),
             tags: msg.tags.clone(),
+            bookmarked: msg.bookmarked,
         }
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -3,7 +3,7 @@ use crate::hl7::types::{Hl7Message, Hl7MessageSummary};
 use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::{broadcast, RwLock};
-use tracing::info;
+use tracing::{info, warn};
 
 const BROADCAST_CAPACITY: usize = 4096;
 
@@ -12,6 +12,7 @@ const BROADCAST_CAPACITY: usize = 4096;
 pub enum StoreEvent {
     NewMessage(Box<Hl7MessageSummary>),
     TagsUpdated(Box<Hl7MessageSummary>),
+    BookmarkToggled(Box<Hl7MessageSummary>),
     Cleared,
 }
 
@@ -50,23 +51,40 @@ impl MessageStore {
         let mut inner = self.inner.write().await;
 
         // Evict oldest 10% when either size or count limit is breached
+        // Bookmarked messages are protected from eviction
         if inner.current_bytes >= inner.max_bytes || inner.messages.len() >= inner.capacity {
-            let drain_count = inner.messages.len() / 10;
-            let freed_bytes: usize = inner
-                .messages
-                .iter()
-                .take(drain_count)
-                .map(|m| m.raw.len())
-                .sum();
-            inner.messages.drain(..drain_count);
-            inner.current_bytes = inner.current_bytes.saturating_sub(freed_bytes);
-            info!(
-                "Evicted {} messages from store ({} MB freed, store now {} messages / {} MB)",
-                drain_count,
-                freed_bytes / 1024 / 1024,
-                inner.messages.len(),
-                inner.current_bytes / 1024 / 1024,
-            );
+            let target_count = inner.messages.len() / 10;
+            let mut evict_indices: Vec<usize> = Vec::with_capacity(target_count);
+            for (i, m) in inner.messages.iter().enumerate() {
+                if evict_indices.len() >= target_count {
+                    break;
+                }
+                if !m.bookmarked {
+                    evict_indices.push(i);
+                }
+            }
+            if evict_indices.is_empty() {
+                warn!(
+                    "Eviction triggered but all candidate messages are bookmarked — skipping eviction"
+                );
+            } else {
+                let freed_bytes: usize = evict_indices
+                    .iter()
+                    .map(|&i| inner.messages[i].raw.len())
+                    .sum();
+                // Remove in reverse order to keep indices valid
+                for &i in evict_indices.iter().rev() {
+                    inner.messages.remove(i);
+                }
+                inner.current_bytes = inner.current_bytes.saturating_sub(freed_bytes);
+                info!(
+                    "Evicted {} messages from store ({} MB freed, store now {} messages / {} MB)",
+                    evict_indices.len(),
+                    freed_bytes / 1024 / 1024,
+                    inner.messages.len(),
+                    inner.current_bytes / 1024 / 1024,
+                );
+            }
         }
 
         inner.current_bytes += msg.raw.len();
@@ -170,6 +188,20 @@ impl MessageStore {
         false
     }
 
+    /// Toggle bookmark on a message, returns the new bookmark state or None if not found
+    pub async fn toggle_bookmark(&self, id: &str) -> Option<bool> {
+        let mut inner = self.inner.write().await;
+        if let Some(msg) = inner.messages.iter_mut().find(|m| m.id == id) {
+            msg.bookmarked = !msg.bookmarked;
+            let new_state = msg.bookmarked;
+            let summary = Hl7MessageSummary::from(&*msg);
+            drop(inner);
+            let _ = self.tx.send(StoreEvent::BookmarkToggled(Box::new(summary)));
+            return Some(new_state);
+        }
+        None
+    }
+
     /// Clear all messages
     pub async fn clear(&self) {
         let mut inner = self.inner.write().await;
@@ -177,5 +209,89 @@ impl MessageStore {
         inner.current_bytes = 0;
         info!("Message store cleared");
         let _ = self.tx.send(StoreEvent::Cleared);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StoreConfig;
+
+    fn make_store(max_messages: usize) -> MessageStore {
+        MessageStore::new(StoreConfig {
+            max_messages,
+            max_memory_mb: 512,
+        })
+    }
+
+    fn make_msg(id: &str) -> Hl7Message {
+        let mut msg = Hl7Message::new_empty(format!("raw-{id}"), "127.0.0.1:5000".into());
+        msg.id = id.to_string();
+        msg
+    }
+
+    #[tokio::test]
+    async fn test_toggle_bookmark_on_off() {
+        let store = make_store(100);
+        let msg = make_msg("a");
+        store.insert(msg).await;
+
+        // Toggle on
+        let result = store.toggle_bookmark("a").await;
+        assert_eq!(result, Some(true));
+        let fetched = store.get_by_id("a").await.unwrap();
+        assert!(fetched.bookmarked);
+
+        // Toggle off
+        let result = store.toggle_bookmark("a").await;
+        assert_eq!(result, Some(false));
+        let fetched = store.get_by_id("a").await.unwrap();
+        assert!(!fetched.bookmarked);
+    }
+
+    #[tokio::test]
+    async fn test_toggle_bookmark_not_found() {
+        let store = make_store(100);
+        assert_eq!(store.toggle_bookmark("nonexistent").await, None);
+    }
+
+    #[tokio::test]
+    async fn test_toggle_bookmark_broadcasts_event() {
+        let store = make_store(100);
+        let msg = make_msg("b");
+        store.insert(msg).await;
+
+        let mut rx = store.subscribe();
+        store.toggle_bookmark("b").await;
+
+        let event = rx.recv().await.unwrap();
+        match event {
+            StoreEvent::BookmarkToggled(summary) => {
+                assert_eq!(summary.id, "b");
+                assert!(summary.bookmarked);
+            }
+            _ => panic!("Expected BookmarkToggled event"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bookmarked_message_survives_eviction() {
+        let store = make_store(10);
+
+        // Insert 10 messages, bookmark the first one
+        for i in 0..10 {
+            let msg = make_msg(&format!("msg-{i}"));
+            store.insert(msg).await;
+        }
+        store.toggle_bookmark("msg-0").await;
+
+        // Insert one more to trigger eviction (10% = 1 message evicted)
+        let msg = make_msg("trigger");
+        store.insert(msg).await;
+
+        // Bookmarked message should survive
+        assert!(store.get_by_id("msg-0").await.is_some());
+        // The first non-bookmarked message should be evicted
+        assert!(store.get_by_id("msg-1").await.is_none());
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -34,6 +34,10 @@ pub fn create_router(state: AppState) -> Router {
             "/api/messages/:id/tags/:tag",
             axum::routing::delete(remove_tag),
         )
+        .route(
+            "/api/messages/:id/bookmark",
+            axum::routing::post(toggle_bookmark),
+        )
         .route("/api/clear", axum::routing::post(clear_messages))
         // WebSocket
         .route("/ws", get(ws_handler))
@@ -137,6 +141,16 @@ async fn remove_tag(
     }
 }
 
+async fn toggle_bookmark(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match state.store.toggle_bookmark(&id).await {
+        Some(bookmarked) => Json(serde_json::json!({"bookmarked": bookmarked})).into_response(),
+        None => (StatusCode::NOT_FOUND, "Message not found").into_response(),
+    }
+}
+
 // --- WebSocket ---
 
 async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
@@ -171,6 +185,15 @@ async fn handle_ws(mut socket: WebSocket, state: AppState) {
                     Ok(StoreEvent::TagsUpdated(summary)) => {
                         let payload = serde_json::json!({
                             "type": "tags_updated",
+                            "data": summary,
+                        });
+                        if socket.send(Message::Text(payload.to_string())).await.is_err() {
+                            break; // client disconnected
+                        }
+                    }
+                    Ok(StoreEvent::BookmarkToggled(summary)) => {
+                        let payload = serde_json::json!({
+                            "type": "bookmark_toggled",
                             "data": summary,
                         });
                         if socket.send(Message::Text(payload.to_string())).await.is_err() {

--- a/static/app.js
+++ b/static/app.js
@@ -18,6 +18,7 @@ let wsReconnectDelay = WS_RECONNECT_INITIAL;
 let paused = false;
 let pendingMessages = [];
 let renderScheduled = false;
+let showBookmarkedOnly = false;
 
 // --- Source Color Mapping ---
 // 12 visually distinct colors optimised for dark backgrounds (HSL, high sat, medium lightness)
@@ -126,7 +127,8 @@ function saveSession() {
             paused,
             collapsedSegments: [...collapsedSegments],
             colorByPort,
-            highlightedSource
+            highlightedSource,
+            showBookmarkedOnly
         }));
     } catch (_) { /* sessionStorage full or unavailable */ }
 }
@@ -143,6 +145,7 @@ function loadSession() {
         if (typeof saved.paused === 'boolean') paused = saved.paused;
         if (typeof saved.colorByPort === 'boolean') colorByPort = saved.colorByPort;
         if (saved.highlightedSource !== undefined) highlightedSource = saved.highlightedSource;
+        if (typeof saved.showBookmarkedOnly === 'boolean') showBookmarkedOnly = saved.showBookmarkedOnly;
         if (Array.isArray(saved.collapsedSegments)) {
             collapsedSegments = new Set(saved.collapsedSegments);
         }
@@ -184,6 +187,8 @@ function connectWs() {
             addMessage(data.data);
         } else if (data.type === 'tags_updated') {
             updateMessageTags(data.data);
+        } else if (data.type === 'bookmark_toggled') {
+            updateMessageBookmark(data.data);
         } else if (data.type === 'lagged') {
             console.warn(`Missed ${data.missed} messages, reloading...`);
             loadMessages();
@@ -211,6 +216,21 @@ function updateMessageTags(summary) {
 
     if (selectedMessage && selectedMessage.id === summary.id) {
         selectedMessage.tags = summary.tags;
+        renderDetail();
+    }
+
+    renderMessageList();
+}
+
+function updateMessageBookmark(summary) {
+    const listMsg = messages.find(m => m.id === summary.id);
+    if (listMsg) listMsg.bookmarked = summary.bookmarked;
+
+    const pendingMsg = pendingMessages.find(m => m.id === summary.id);
+    if (pendingMsg) pendingMsg.bookmarked = summary.bookmarked;
+
+    if (selectedMessage && selectedMessage.id === summary.id) {
+        selectedMessage.bookmarked = summary.bookmarked;
         renderDetail();
     }
 
@@ -295,9 +315,12 @@ async function pollStats() {
 function renderMessageList() {
     const list = document.getElementById('message-list');
     const empty = document.getElementById('empty-state');
-    const filtered = searchQuery
+    let filtered = searchQuery
         ? messages.filter(m => matchesSearch(m, searchQuery))
         : messages;
+    if (showBookmarkedOnly) {
+        filtered = filtered.filter(m => m.bookmarked);
+    }
 
     if (filtered.length === 0) {
         empty.style.display = 'flex';
@@ -347,6 +370,9 @@ function renderMessageList() {
             ? `<span class="msg-ack" style="${ackColor}">${esc(msg.ack_code)}</span>`
             : `<span class="msg-ack">—</span>`;
 
+        const bookmarkClass = msg.bookmarked ? 'msg-bookmark active' : 'msg-bookmark';
+        const bookmarkIcon = msg.bookmarked ? '★' : '☆';
+
         row.innerHTML = `
             ${dotHtml}
             <div style="display:flex; flex-direction:column; gap:2px; overflow:hidden;">
@@ -358,6 +384,7 @@ function renderMessageList() {
             <span class="msg-time">${timeStr}</span>
             <span class="msg-segs">${msg.segment_count}</span>
             ${ackHtml}
+            <span class="${bookmarkClass}" onclick="toggleBookmark('${msg.id}', event)" title="Bookmark">${bookmarkIcon}</span>
         `;
         fragment.appendChild(row);
     }
@@ -415,7 +442,12 @@ function renderDetail() {
         return el;
     })();
 
-    tagsContainer.innerHTML = (msg.tags || []).map(t =>
+    const bookmarkBtnClass = msg.bookmarked ? 'detail-bookmark-btn active' : 'detail-bookmark-btn';
+    const bookmarkBtnIcon = msg.bookmarked ? '★' : '☆';
+
+    tagsContainer.innerHTML = `
+        <button class="${bookmarkBtnClass}" onclick="toggleBookmark('${msg.id}', event)" title="Toggle bookmark">${bookmarkBtnIcon} Bookmark</button>
+    ` + (msg.tags || []).map(t =>
         `<span class="msg-tag">${esc(t)} <span class="msg-tag-remove" onclick="removeTag('${msg.id}', '${escAttr(t)}')">×</span></span>`
     ).join('') + `
         <div class="msg-tag-add">
@@ -599,6 +631,32 @@ async function removeTag(id, tag) {
     }
 }
 
+async function toggleBookmark(id, event) {
+    event.stopPropagation();
+    try {
+        const resp = await fetch(`/api/messages/${id}/bookmark`, { method: 'POST' });
+        if (!resp.ok) throw new Error('Failed to toggle bookmark');
+    } catch (e) {
+        showToast(e.message);
+    }
+}
+
+function toggleBookmarkFilter() {
+    showBookmarkedOnly = !showBookmarkedOnly;
+    const btn = document.getElementById('btn-bookmarks');
+    if (showBookmarkedOnly) {
+        btn.textContent = '★ Bookmarks';
+        btn.style.borderColor = 'var(--warning)';
+        btn.style.color = 'var(--warning)';
+    } else {
+        btn.textContent = '☆ Bookmarks';
+        btn.style.borderColor = '';
+        btn.style.color = '';
+    }
+    renderMessageList();
+    saveSession();
+}
+
 // --- Utility ---
 function showToast(message, type = 'error') {
     const toast = document.createElement('div');
@@ -733,6 +791,13 @@ document.addEventListener('click', (e) => {
     if (paused) {
         const btn = document.getElementById('btn-pause');
         btn.textContent = '▶ Live';
+        btn.style.borderColor = 'var(--warning)';
+        btn.style.color = 'var(--warning)';
+    }
+
+    if (showBookmarkedOnly) {
+        const btn = document.getElementById('btn-bookmarks');
+        btn.textContent = '★ Bookmarks';
         btn.style.borderColor = 'var(--warning)';
         btn.style.color = 'var(--warning)';
     }

--- a/static/index.html
+++ b/static/index.html
@@ -29,6 +29,7 @@
         <div class="header-actions">
             <button onclick="togglePause()" id="btn-pause" title="Pause live updates">⏸ Pause</button>
             <button onclick="toggleAutoscroll()" id="btn-autoscroll" title="Auto-scroll">⬇ Auto</button>
+            <button onclick="toggleBookmarkFilter()" id="btn-bookmarks" title="Show bookmarked only">☆ Bookmarks</button>
             <button onclick="exportMessages()" title="Export JSON">📥 Export</button>
             <button class="danger" onclick="clearMessages()" title="Clear all">🗑 Clear</button>
         </div>
@@ -48,6 +49,7 @@
                 <span>Time</span>
                 <span>Segs</span>
                 <span>ACK</span>
+                <span></span>
             </div>
             <div class="message-list" id="message-list">
                 <div class="empty-state" id="empty-state">

--- a/static/style.css
+++ b/static/style.css
@@ -226,7 +226,7 @@ body.resizing * {
 
 .message-row {
     display: grid;
-    grid-template-columns: 12px 100px 90px 1fr 140px 60px 40px;
+    grid-template-columns: 12px 100px 90px 1fr 140px 60px 40px 24px;
     gap: 12px;
     padding: 9px 16px;
     border-bottom: 1px solid var(--border);
@@ -298,7 +298,7 @@ body.resizing * {
 
 .list-header {
     display: grid;
-    grid-template-columns: 12px 100px 90px 1fr 140px 60px 40px;
+    grid-template-columns: 12px 100px 90px 1fr 140px 60px 40px 24px;
     gap: 12px;
     padding: 7px 16px;
     font-size: 10px;
@@ -759,4 +759,44 @@ body.resizing * {
     font-size: 12px;
     line-height: 1;
     height: 20px;
+}
+
+/* Bookmark star in message row */
+.msg-bookmark {
+    cursor: pointer;
+    font-size: 14px;
+    color: var(--text-muted);
+    transition: color 0.15s;
+    text-align: center;
+    user-select: none;
+}
+
+.msg-bookmark:hover {
+    color: var(--warning);
+}
+
+.msg-bookmark.active {
+    color: var(--warning);
+}
+
+/* Bookmark button in detail view */
+.detail-bookmark-btn {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 14px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.detail-bookmark-btn:hover {
+    color: var(--warning);
+    border-color: var(--warning);
+}
+
+.detail-bookmark-btn.active {
+    color: var(--warning);
+    border-color: var(--warning);
 }


### PR DESCRIPTION
## Summary
- **Star icon (★/☆)** on each message row — click to toggle bookmark, prevents row selection via `stopPropagation()`
- **"★ Bookmarks" filter button** in header — shows only bookmarked messages when active (warning color)
- **Bookmark button in detail view** alongside tags
- **Eviction protection** — bookmarked messages are skipped during store eviction (warns if all candidates are bookmarked)
- **Real-time sync** — `StoreEvent::BookmarkToggled` broadcasts via WebSocket, updates all connected tabs
- **Session persistence** — `showBookmarkedOnly` filter state stored in `sessionStorage`
- **4 unit tests** — toggle on/off, not-found, broadcast event, eviction survival
- **Git workflow rule** added to `AGENTS.md` and `CLAUDE.md` requiring feature branches + PRs

### Files Changed
| File | Change |
|------|--------|
| `src/hl7/types.rs` | `bookmarked: bool` on `Hl7Message` + `Hl7MessageSummary` |
| `src/store.rs` | `BookmarkToggled` event, `toggle_bookmark()`, eviction protection, 4 tests |
| `src/web.rs` | `POST /api/messages/:id/bookmark` endpoint, WebSocket arm |
| `static/app.js` | Toggle, filter, WS handler, session persistence, detail view |
| `static/index.html` | Bookmarks button, 8th column header |
| `static/style.css` | 8-column grid, `.msg-bookmark`, `.detail-bookmark-btn` styles |
| `AGENTS.md` / `CLAUDE.md` | "Git Workflow — Branch + PR Required" rule |

Closes #27

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — 17 tests pass (4 new bookmark tests)
- [x] Manual: send test messages via `./test.sh`, click star on rows, verify toggle
- [x] Manual: click "★ Bookmarks" filter, verify only bookmarked messages shown
- [x] Manual: open two tabs, bookmark in one, verify sync in other
- [x] Manual: lower capacity, verify bookmarked message survives eviction

🤖 Generated with [Claude Code](https://claude.com/claude-code)