### PR TITLE
Fix string interpolation in test.ps1

### DIFF
--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -23,7 +23,7 @@ function Send-Hl7Message {
         [string]$Payload
     )
 
-    Write-Host "=> Sending $TestName to $Server:$Port" -ForegroundColor Cyan
+    Write-Host "=> Sending $TestName to ${Server}:${Port}" -ForegroundColor Cyan
 
     # HL7 segments must be separated by \r (Carriage Return), not \n.
     $formattedPayload = $Payload.Trim() -replace "`r?`n", $CR
@@ -49,7 +49,7 @@ function Send-Hl7Message {
             $response = [System.Text.Encoding]::UTF8.GetString($buffer, 0, $bytesRead)
 
             # Strip MLLP wrappers and make readable
-            $cleanResponse = $response.Replace($SB, '').Replace($EB, '').Replace($CR, "`n")
+            $cleanResponse = $response -replace "$SB", "" -replace "$EB", "" -replace "$CR", "`n"
             Write-Host "   [SERVER-ACK]:`n$cleanResponse"
         } else {
             Write-Host "   [SERVER-ACK]: (No response received within timeout)" -ForegroundColor Yellow
@@ -124,7 +124,7 @@ function Invoke-Hl7LoadTest {
 # Run Functional Tests
 # ==========================================
 
-Write-Host "Starting HL7 MLLP functional tests against $Server:$Port..."
+Write-Host "Starting HL7 MLLP functional tests against ${Server}:${Port}..."
 Write-Host "=================================================="
 
 Get-ChildItem "$MsgDir\valid\*.hl7" | Sort-Object Name | ForEach-Object {


### PR DESCRIPTION
Powershell-Script had two small Errors. 

- The Variable $Server and $Port need to be placed inside ${...}.
- Also an Error happens because in the Script were $SB and $EB as [char] declared. When you call the .NET .Replace() method and pass a [char] as the first argument, the method strictly expects a [char] as the second argument as well. Since we passed an empty string '', PowerShell throws an error because an empty string isn't exactly one character long. Changed to PowerShell's native -replace operator.
