### PR TITLE
⚡ Bolt: optimize dictionary lookup to O(1) where possible

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-08 - [O(1) Dictionary Lookup]
+**Learning:** O(1) dictionary lookup for HL7 field descriptions using direct indexing can be risky because fields might not always be perfectly ordered without gaps. The correct approach is to attempt an O(1) direct index lookup, but gracefully fallback to an O(n) iter().find() if the field sequence does not match the index.
+**Action:** Always consider the fallback mechanisms when introducing structural assumptions for optimization, especially around array bounds or specific sequences.

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -38,8 +38,18 @@ pub fn get_field_description(version: &str, segment: &str, field_seq: usize) -> 
     let dict = get_v251();
 
     if let Some(seg_def) = dict.segments.get(segment) {
-        // Find field definition by sequence number (1-based)
-        if let Some(field_def) = seg_def.fields.iter().find(|f| f.seq == field_seq) {
+        // Try O(1) fast-path first assuming perfect sequence, fallback to O(N) search.
+        let field_def = if field_seq > 0 {
+            seg_def.fields.get(field_seq - 1)
+        } else {
+            None
+        };
+
+        let field_def = field_def
+            .filter(|f| f.seq == field_seq)
+            .or_else(|| seg_def.fields.iter().find(|f| f.seq == field_seq));
+
+        if let Some(field_def) = field_def {
             return Some(field_def.desc.clone());
         }
     }
@@ -58,7 +68,17 @@ pub fn inject_descriptions(segments: &mut [crate::hl7::types::Hl7Segment], versi
         if let Some(seg_def) = dict.segments.get(&seg_name) {
             segment.description = Some(seg_def.desc.clone());
             for field in segment.fields.iter_mut() {
-                if let Some(field_def) = seg_def.fields.iter().find(|f| f.seq == field.index) {
+                let field_def = if field.index > 0 {
+                    seg_def.fields.get(field.index - 1)
+                } else {
+                    None
+                };
+
+                let field_def = field_def
+                    .filter(|f| f.seq == field.index)
+                    .or_else(|| seg_def.fields.iter().find(|f| f.seq == field.index));
+
+                if let Some(field_def) = field_def {
                     field.description = Some(field_def.desc.clone());
                 }
             }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -376,7 +376,16 @@ fn validate_data_types(msg: &Hl7Message, warnings: &mut Vec<ValidationWarning>) 
             if field.value.is_empty() {
                 continue; // empty values are caught by MISSING_FIELD rules
             }
-            let Some(field_def) = seg_def.fields.iter().find(|f| f.seq == field.index) else {
+            let field_def = if field.index > 0 {
+                seg_def.fields.get(field.index - 1)
+            } else {
+                None
+            };
+
+            let Some(field_def) = field_def
+                .filter(|f| f.seq == field.index)
+                .or_else(|| seg_def.fields.iter().find(|f| f.seq == field.index))
+            else {
                 continue;
             };
             // Use only the first component — composite values include sub-component


### PR DESCRIPTION
Replaced O(N) linear searches in HL7 dictionary lookups with O(1) fast-path indexing, while gracefully falling back to O(N) when fields have sequence gaps.

## Description

<!-- What does this PR do? Why is it needed? -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. "Closes #42" -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no functional change)
- [ ] 🧪 Test improvement
- [ ] 🔧 CI / build / tooling

## Component(s) Affected

- [ ] MLLP Server (`mllp.rs`)
- [ ] HL7 Parser (`hl7/`)
- [ ] Message Store (`store.rs`)
- [ ] Web Server / API (`web.rs`)
- [ ] Web UI (`static/`)
- [ ] Build / CI (`.github/`)
- [ ] Documentation

## How to Test

<!-- Steps for the reviewer to verify this change works -->

1. ...
2. ...

## Checklist

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` is clean
- [ ] `cargo fmt --check` passes
- [ ] I updated `CHANGELOG.md` under `[Unreleased]` (if user-facing)
- [ ] I added/updated tests for new behavior
- [ ] I added doc comments for new public types/functions

## Screenshots

<!-- If this changes the Web UI, include before/after screenshots -->
