### PR TITLE
fix: resolve XSS vulnerability in HTML attribute injection

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -101,7 +101,7 @@ function renderSourceLegend() {
         const isDimmed = highlightedSource && highlightedSource !== label;
         const classes = `source-legend-item${isHighlighted ? ' highlighted' : ''}${isDimmed ? ' dimmed' : ''}`;
 
-        return `<span class="${classes}" onclick="toggleHighlightSource('${esc(label)}')">
+        return `<span class="${classes}" onclick="toggleHighlightSource('${escAttr(escJS(label))}')">
             <span class="source-dot" style="background:${color};box-shadow:0 0 4px ${color}"></span>
             ${esc(label)}
         </span>`;
@@ -498,7 +498,7 @@ function renderDetail() {
         <button class="${bookmarkBtnClass}" onclick="toggleBookmark('${msg.id}', event)" title="Toggle bookmark">${bookmarkBtnIcon} Bookmark</button>
         <button class="${pinBtnClass}" onclick="toggleDiffPin('${msg.id}')" title="Pin this message as the diff reference">${pinBtnLabel}</button>
     ` + (msg.tags || []).map(t =>
-        `<span class="msg-tag">${esc(t)} <span class="msg-tag-remove" onclick="removeTag('${msg.id}', '${escAttr(t)}')">×</span></span>`
+        `<span class="msg-tag">${esc(t)} <span class="msg-tag-remove" onclick="removeTag('${msg.id}', '${escAttr(escJS(t))}')">×</span></span>`
     ).join('') + `
         <div class="msg-tag-add">
             <input type="text" id="add-tag-input" placeholder="Add tag" onkeypress="if(event.key === 'Enter') addTag('${msg.id}', this.value)">
@@ -964,6 +964,15 @@ function escAttr(str) {
         .replace(/'/g, '&#x27;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;');
+}
+
+function escJS(str) {
+    if (!str) return '';
+    return str.replace(/\\/g, '\\\\')
+        .replace(/'/g, '\\\'')
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, '\\n')
+        .replace(/\r/g, '\\r');
 }
 
 // --- Copy to Clipboard ---


### PR DESCRIPTION
Fixes a Cross-Site Scripting (XSS) vulnerability in `static/app.js` where user-provided strings were interpolated into `onclick` attribute handlers. The `escAttr` function alone was insufficient as HTML parsers decode entities before the JavaScript engine executes the code, allowing attackers to break out of the string literal.

This commit introduces an `escJS` helper function to escape single quotes, double quotes, newlines, and backslashes for safe interpolation inside JavaScript strings. The fix is applied to both the `removeTag` feature and the `toggleHighlightSource` feature which suffered from the same vulnerability.

## Description

<!-- What does this PR do? Why is it needed? -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. "Closes #42" -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no functional change)
- [ ] 🧪 Test improvement
- [ ] 🔧 CI / build / tooling

## Component(s) Affected

- [ ] MLLP Server (`mllp.rs`)
- [ ] HL7 Parser (`hl7/`)
- [ ] Message Store (`store.rs`)
- [ ] Web Server / API (`web.rs`)
- [ ] Web UI (`static/`)
- [ ] Build / CI (`.github/`)
- [ ] Documentation

## How to Test

<!-- Steps for the reviewer to verify this change works -->

1. ...
2. ...

## Checklist

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` is clean
- [ ] `cargo fmt --check` passes
- [ ] I updated `CHANGELOG.md` under `[Unreleased]` (if user-facing)
- [ ] I added/updated tests for new behavior
- [ ] I added doc comments for new public types/functions

## Screenshots

<!-- If this changes the Web UI, include before/after screenshots -->
