### PR TITLE
feat(a11y): keyboard navigation for message list rows

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-08 - Added keyboard accessibility to custom list items
+**Learning:** When using `div` elements as clickable rows in a list, setting `onclick` is not enough for keyboard accessibility. Screen reader and keyboard-only users cannot interact with them.
+**Action:** Always add `tabIndex="0"`, `role="button"`, an `onkeydown` handler for 'Enter'/'Space', and a `:focus-visible` CSS pseudo-class to ensure custom interactive elements are fully accessible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 | Commit | Description |
 |--------|-------------|
 | [`a14f0de`](https://github.com/Pappet/harux/commit/a14f0de20053257e6b9cd2b9e6063fc8e2daf8dc) | `fix:` resolve ISO-8859-1 charset encoding issues (#78) |
-| [`310a909`](https://github.com/Pappet/harux/commit/310a9095c94ebd7ad1f773ead15ed311eb1eff58) | `feat(a11y):` keyboard navigation for message list rows |
+| [`1993bcb`](https://github.com/Pappet/harux/commit/1993bcb07709460bce5d468c046be6e2f1db533c) | `feat(a11y):` keyboard navigation for message list rows |
 
 #### 2026-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 ## [Unreleased]
 
+### Added
+- **Keyboard accessibility for message rows** — message list rows now support `Tab` focus navigation and `Enter`/`Space` to select; a 2px accent outline appears on `:focus-visible`. Improves screen-reader and keyboard-only workflows.
+
 ---
 
 ## [0.4.0] – 2026-03-08 – Message Analysis
@@ -45,6 +48,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 | Commit | Description |
 |--------|-------------|
 | [`a14f0de`](https://github.com/Pappet/harux/commit/a14f0de20053257e6b9cd2b9e6063fc8e2daf8dc) | `fix:` resolve ISO-8859-1 charset encoding issues (#78) |
+| [`310a909`](https://github.com/Pappet/harux/commit/310a9095c94ebd7ad1f773ead15ed311eb1eff58) | `feat(a11y):` keyboard navigation for message list rows |
 
 #### 2026-03-08
 

--- a/static/app.js
+++ b/static/app.js
@@ -365,7 +365,15 @@ function renderMessageList() {
 
         row.className = rowClass;
         row.dataset.id = msg.id;
+        row.tabIndex = 0;
+        row.setAttribute('role', 'button');
         row.onclick = () => selectMessage(msg.id);
+        row.onkeydown = (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                selectMessage(msg.id);
+            }
+        };
 
         const time = new Date(msg.received_at);
         const yyyy = time.getFullYear();

--- a/static/style.css
+++ b/static/style.css
@@ -233,8 +233,13 @@ body.resizing * {
     border-left: 3px solid transparent;
     font-size: 12px;
     cursor: pointer;
-    transition: background 0.1s, opacity 0.15s, border-left-color 0.15s;
+    transition: background 0.1s, opacity 0.15s, border-left-color 0.15s, outline 0.1s;
     align-items: center;
+}
+
+.message-row:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
 }
 
 .message-row.dimmed {


### PR DESCRIPTION
## Summary

Cherry-picked from Jules' branch [`palette-ux-message-row-focus-4294854144968052910`](https://github.com/Pappet/harux/tree/palette-ux-message-row-focus-4294854144968052910), keeping **only the accessibility hunks** from commit `bba9975`.

### What this PR does
- `static/app.js` — every row in `renderMessageList` gets `tabIndex = 0`, `role = "button"`, and an `onkeydown` handler. `Enter` and `Space` invoke `selectMessage`. `Space` calls `e.preventDefault()` so the page does not scroll.
- `static/style.css` — `.message-row:focus-visible` paints a 2 px `var(--accent)` outline with a -2 px offset, so the focus ring sits inside the row and reads against both the default and selected backgrounds. `outline` is added to the existing transition list for a smooth fade.
- `.jules/palette.md` — Jules' learning note preserved in the existing lowercase `.jules/` directory (matching `.jules/bolt.md` and `.jules/sentinel.md`), instead of the new `.Jules/` from the source branch.

### What this PR does NOT do (and why)

The source branch contained three additional changes that **were intentionally excluded**, because each one would have regressed work that already shipped to `main`:

1. **`src/dictionary.rs` and `src/validation.rs`** — the source branch reverted #83 (Bolt's O(N) → O(1) dictionary lookup), going back to plain `.iter().find()`. We kept the optimization.
2. **`static/app.js` `escJS` removal** — the source branch deleted the `escJS` helper and replaced its callers with `escAttr`. PR #84 explicitly states this is unsafe: "the `escAttr` function alone was insufficient as HTML parsers decode entities before the JavaScript engine executes the code, allowing attackers to break out of the string literal." Removing `escJS` would re-introduce the XSS hole. We kept it.
3. **`scratch.rs` deletion and `.jules/bolt.md` deletion** — left untouched. `bolt.md` is Bolt's learning note for #83 and stays alongside the new `palette.md`. `scratch.rs` (a debug aid for #82) was already removed in a separate commit on `main`.

Net result: this PR is a strict subset of the source branch — only the accessibility win, none of the regressions.

## Test plan

- [ ] CI: `cargo fmt --check` passes
- [ ] CI: `cargo clippy -- -D warnings` passes
- [ ] CI: `cargo build` and `cargo test` pass
- [ ] Manual: open the UI, press `Tab` until a message row receives focus — confirm the 2 px accent outline appears.
- [ ] Manual: with a row focused, press `Enter` — the message detail should open exactly as if it were clicked.
- [ ] Manual: with a row focused, press `Space` — the message detail should open and the page should NOT scroll.
- [ ] Manual: select a row with the mouse first, then `Tab` to it — the focus outline should still be visible on top of the selected-row background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)