### PR TITLE
feat(a11y): ARIA labels, native buttons, global focus ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 ### Added
 - **Keyboard accessibility for message rows** — message list rows now support `Tab` focus navigation and `Enter`/`Space` to select; a 2px accent outline appears on `:focus-visible`. Improves screen-reader and keyboard-only workflows.
+- **ARIA labels on message rows + bookmark/pin controls** — each row exposes a synthesized `aria-label` (facility, type, time); the bookmark and pin controls were promoted from `<span>` to native `<button>` so they receive `Tab` focus, keyboard activation, and `aria-label`. Pin clicks now `stopPropagation` so the row beneath does not also select.
+- **Global `:focus-visible` outline** — every focusable element gets a 2 px accent outline when reached via keyboard, addressing missing focus rings across header buttons, search input, and inline controls.
+
+### Fixed
+- **Pin click leaked to row selection** — clicking the diff-pin icon previously also selected the underlying message row. `toggleDiffPin` now calls `event.stopPropagation()` when invoked from the row.
 
 ### Changed
 - **Typography** — adopted Inter (sans) and JetBrains Mono (mono) via Google Fonts; first phase of the v0.5.0 UI redesign (#86)
@@ -52,6 +57,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 | Commit | Description |
 |--------|-------------|
 | [`a14f0de`](https://github.com/Pappet/harux/commit/a14f0de20053257e6b9cd2b9e6063fc8e2daf8dc) | `fix:` resolve ISO-8859-1 charset encoding issues (#78) |
+| [`a6f1ce7`](https://github.com/Pappet/harux/commit/a6f1ce7e1e8deb5dbead3248e099423231b1cd09) | `feat(a11y):` ARIA labels, native buttons, global focus ring |
 | [`1993bcb`](https://github.com/Pappet/harux/commit/1993bcb07709460bce5d468c046be6e2f1db533c) | `feat(a11y):` keyboard navigation for message list rows |
 | [`f5c650a`](https://github.com/Pappet/harux/commit/f5c650aa025132a5a6e660092957fd3ad69099ec) | `feat(ui):` typography + color foundation for v0.5.0 redesign (#86) |
 

--- a/static/app.js
+++ b/static/app.js
@@ -367,6 +367,7 @@ function renderMessageList() {
         row.dataset.id = msg.id;
         row.tabIndex = 0;
         row.setAttribute('role', 'button');
+        row.setAttribute('aria-label', `Message from ${msg.sending_facility || 'unknown'}, type ${msg.message_type || 'unknown'}, received ${msg.received_at}`);
         row.onclick = () => selectMessage(msg.id);
         row.onkeydown = (e) => {
             if (e.key === 'Enter' || e.key === ' ') {
@@ -411,6 +412,7 @@ function renderMessageList() {
 
         const bookmarkClass = msg.bookmarked ? 'msg-bookmark active' : 'msg-bookmark';
         const bookmarkIcon = msg.bookmarked ? '★' : '☆';
+        const bookmarkLabel = msg.bookmarked ? 'Remove bookmark' : 'Add bookmark';
 
         const isPinned = diffPinnedMessage && diffPinnedMessage.id === msg.id;
         const pinClass = isPinned ? 'msg-pin active' : 'msg-pin';
@@ -428,8 +430,8 @@ function renderMessageList() {
             <span class="msg-time">${timeStr}</span>
             <span class="msg-segs">${msg.segment_count}</span>
             ${ackHtml}
-            <span class="${bookmarkClass}" onclick="toggleBookmark('${msg.id}', event)" title="Bookmark">${bookmarkIcon}</span>
-            <span class="${pinClass}" onclick="toggleDiffPin('${msg.id}')" title="${pinTitle}">${pinIcon}</span>
+            <button class="${bookmarkClass}" aria-label="${bookmarkLabel}" onclick="toggleBookmark('${msg.id}', event)" title="Bookmark">${bookmarkIcon}</button>
+            <button class="${pinClass}" aria-label="${pinTitle}" onclick="toggleDiffPin('${msg.id}', event)" title="${pinTitle}">${pinIcon}</button>
         `;
         fragment.appendChild(row);
     }
@@ -533,7 +535,8 @@ function renderDetail() {
     renderTab();
 }
 
-async function toggleDiffPin(id) {
+async function toggleDiffPin(id, event) {
+    if (event) event.stopPropagation();
     if (diffPinnedMessage && diffPinnedMessage.id === id) {
         diffPinnedMessage = null;
         renderMessageList();

--- a/static/style.css
+++ b/static/style.css
@@ -32,6 +32,12 @@ body {
     overflow: hidden;
 }
 
+*:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
 /* Header */
 header {
     display: flex;
@@ -803,17 +809,31 @@ body.resizing * {
     height: 20px;
 }
 
-/* Bookmark star in message row */
-.msg-bookmark {
-    cursor: pointer;
-    font-size: 14px;
+/* Bookmark / pin buttons in message row — flat icon buttons */
+.msg-bookmark,
+.msg-pin {
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
     color: var(--text-muted);
+    cursor: pointer;
     transition: color 0.15s;
     text-align: center;
     user-select: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    font-family: inherit;
+}
+
+.msg-bookmark {
+    font-size: 14px;
 }
 
 .msg-bookmark:hover {
+    background: transparent;
     color: var(--warning);
 }
 
@@ -822,15 +842,11 @@ body.resizing * {
 }
 
 .msg-pin {
-    cursor: pointer;
     font-size: 13px;
-    color: var(--text-muted);
-    transition: color 0.15s;
-    text-align: center;
-    user-select: none;
 }
 
 .msg-pin:hover {
+    background: transparent;
     color: var(--accent);
 }
 


### PR DESCRIPTION
## Summary

Cherry-picked from Jules' branch [`feat/ux-keyboard-accessibility-2298867385226723355`](https://github.com/Pappet/harux/tree/feat/ux-keyboard-accessibility-2298867385226723355) (commit `36ff3fe`). The bot branch was based on a stale `main` (`818a59d`), so a direct merge would have looked like a mass deletion of everything that landed since — Phase 1 fonts/colors (#87), the baseline a11y work (#88), and the XSS fixes (#84, #85). This PR carries only the incremental hunks on top of current `main`.

Builds on the row keyboard navigation already shipped in #88.

### Changes

- `static/app.js`
  - Each message row gains an `aria-label` synthesized from `sending_facility`, `message_type`, and `received_at` — screen readers announce the row contents instead of "button".
  - Bookmark and pin icons promoted from `<span>` to native `<button>`. Both gain `aria-label`. Native button handles `Enter` / `Space` activation without extra plumbing.
  - `toggleDiffPin(id)` → `toggleDiffPin(id, event)`. Calls `event.stopPropagation()` when an event is provided, so a pin click no longer also selects the underlying row. The detail-panel call site (no event) keeps working because the parameter is optional.

- `static/style.css`
  - Global `*:focus-visible` rule paints a 2 px accent outline with 2 px offset on every keyboard-focusable element. Layers benignly with the existing `.search-bar input:focus` border treatment.
  - `.msg-bookmark` / `.msg-pin` get a button reset (transparent background, no border, zero padding, flex centring, `font-family: inherit`) so the swap from span to button is visually invisible.
  - The `.message-row:focus-visible` rule already on `main` from #88 was intentionally not duplicated.

### What was NOT carried over from the source branch
- Duplicate `.message-row:focus-visible` (already present from #88).

### Why XSS-safe
The new `aria-label` value uses `setAttribute`, not innerHTML interpolation. The DOM API does not parse HTML in attribute values, so untrusted `sending_facility` / `message_type` content cannot escape the attribute boundary. No `escAttr` / `escJS` needed for this path.

## Test plan

- [ ] CI: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test`
- [ ] Manual: `Tab` through the message list — every row reads its aria-label in VoiceOver / NVDA.
- [ ] Manual: `Tab` to a bookmark or pin button — `Enter` / `Space` toggles state without selecting the row beneath.
- [ ] Manual: click the pin icon — only the pin toggles; row selection is unchanged.
- [ ] Manual: focus the search input, header buttons, detail-tab buttons — confirm the new global accent outline appears on `:focus-visible` (keyboard) but NOT on click (mouse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)