### PR TITLE
Redesign Phase 2: top-bar health pills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 ### Changed
 - **Typography** — adopted Inter (sans) and JetBrains Mono (mono) via Google Fonts; first phase of the v0.5.0 UI redesign (#86)
 - **Color palette** — refreshed dark theme: deeper backgrounds (`--bg-primary` `#0b0d12`, `--bg-secondary` `#131620`, `--bg-tertiary` `#1b1f2c`), cooler accent (`--accent` `#7aa2ff`), tuned success/error tones (`--success` `#4fb98a`, `--error` `#ea6363`) for higher contrast against the deeper canvas (#86)
+- **Top-bar health pills** — replaced the dot-and-counter `.stats-bar` with a row of pill-shaped status indicators: `listening :PORT` (green pulsing dot when WebSocket connected, red static when disconnected), `conns N / MAX`, `rate N/min` with a 60-second sparkline, `last Ns ago` (refreshed once per second), `errors N` (red value when nonzero). The previously hidden "rejected" stat is preserved as a hidden pill that surfaces only when `rejected_connections > 0`. The `total messages` counter was removed from the header; the rolling rate pill replaces it as the live-traffic signal (#92)
 
 ---
 
@@ -58,6 +59,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 |--------|-------------|
 | [`a14f0de`](https://github.com/Pappet/harux/commit/a14f0de20053257e6b9cd2b9e6063fc8e2daf8dc) | `fix:` resolve ISO-8859-1 charset encoding issues (#78) |
 | [`a6f1ce7`](https://github.com/Pappet/harux/commit/a6f1ce7e1e8deb5dbead3248e099423231b1cd09) | `feat(a11y):` ARIA labels, native buttons, global focus ring |
+| [`4554d90`](https://github.com/Pappet/harux/commit/4554d90488df2bd604f1017d024013cd08331f72) | `feat(ui):` top-bar health pills replace stats dots (#92) |
 | [`1993bcb`](https://github.com/Pappet/harux/commit/1993bcb07709460bce5d468c046be6e2f1db533c) | `feat(a11y):` keyboard navigation for message list rows |
 | [`f5c650a`](https://github.com/Pappet/harux/commit/f5c650aa025132a5a6e660092957fd3ad69099ec) | `feat(ui):` typography + color foundation for v0.5.0 redesign (#86) |
 

--- a/static/app.js
+++ b/static/app.js
@@ -24,6 +24,10 @@ let validationFilter = 0; // 0: All, 1: Warnings, 2: Errors Only
 // Server state for accurate total message count
 let totalMessagesCount = 0;
 
+// Health-pill state: rolling 60-second window of message timestamps.
+const rateWindow = [];               // Date.now() timestamps within last 60 s
+let lastMessageReceivedAt = null;    // Date.now() of most recent addMessage
+
 // Segment diff state
 let diffPinnedMessage = null; // the reference message pinned for comparison
 let diffIgnoreDynamic = false;
@@ -172,30 +176,26 @@ function connectWs() {
 
     ws.onopen = () => {
         wsReconnectDelay = WS_RECONNECT_INITIAL; // reset on success
-        document.getElementById('ws-dot').className = 'stat-dot green';
-        document.getElementById('ws-status').textContent = 'Connected';
+        setListeningPillState('live');
     };
 
     ws.onclose = () => {
-        document.getElementById('ws-dot').className = 'stat-dot red';
         const jitter = wsReconnectDelay * (0.75 + Math.random() * 0.5);
         const delaySec = Math.round(jitter / 1000);
-        document.getElementById('ws-status').textContent = `Reconnecting in ${delaySec}s\u2026`;
+        setListeningPillState('disconnected', `Reconnecting in ${delaySec}s\u2026`);
         setTimeout(connectWs, jitter);
         wsReconnectDelay = Math.min(wsReconnectDelay * WS_RECONNECT_MULT, WS_RECONNECT_MAX);
     };
 
     ws.onerror = (event) => {
         console.error('WebSocket error:', event);
-        document.getElementById('ws-dot').className = 'stat-dot red';
-        document.getElementById('ws-status').textContent = 'Error';
+        setListeningPillState('disconnected', 'WebSocket error');
     };
 
     ws.onmessage = (event) => {
         const data = JSON.parse(event.data);
         if (data.type === 'init') {
             totalMessagesCount = data.total;
-            document.getElementById('stat-total').textContent = totalMessagesCount;
             loadMessages();
         } else if (data.type === 'new_message') {
             addMessage(data.data);
@@ -211,13 +211,15 @@ function connectWs() {
             messages = [];
             pendingMessages = [];
             totalMessagesCount = 0;
+            rateWindow.length = 0;
+            lastMessageReceivedAt = null;
             selectedId = null;
             selectedMessage = null;
             renderMessageList();
+            renderHealthPills();
             document.getElementById('detail-content').innerHTML = '<div class="empty-state"><p>No message selected</p></div>';
             document.getElementById('detail-title').textContent = 'Select a message';
             document.getElementById('detail-meta').textContent = '';
-            document.getElementById('stat-total').textContent = '0';
         }
     };
 }
@@ -258,7 +260,9 @@ function addMessage(summary) {
     // Register source for color mapping
     registerSource(summary.source_addr);
     totalMessagesCount++;
-    document.getElementById('stat-total').textContent = totalMessagesCount;
+    const now = Date.now();
+    rateWindow.push(now);
+    lastMessageReceivedAt = now;
     if (!paused) {
         scheduleRender();
     }
@@ -278,7 +282,6 @@ function flushAndRender() {
         messages = [...pendingMessages, ...messages];
         pendingMessages = [];
     }
-    document.getElementById('stat-total').textContent = totalMessagesCount;
     renderMessageList();
     renderSourceLegend();
 }
@@ -293,7 +296,6 @@ async function loadMessages() {
         for (const m of messages) {
             registerSource(m.source_addr);
         }
-        document.getElementById('stat-total').textContent = totalMessagesCount;
         renderMessageList();
         renderSourceLegend();
     } catch (e) {
@@ -308,23 +310,109 @@ async function pollStats() {
         if (!resp.ok) return;
         const stats = await resp.json();
         totalMessagesCount = stats.total_messages;
-        document.getElementById('stat-total').textContent = totalMessagesCount;
-        document.getElementById('stat-connections').textContent =
+
+        // conns pill
+        document.getElementById('pill-conns-value').textContent =
             `${stats.active_connections} / ${stats.max_connections}`;
-        document.getElementById('stat-errors').textContent = stats.parse_errors;
-        const rejectedEl = document.getElementById('stat-rejected');
-        if (rejectedEl) {
+
+        // errors pill — paint value red when nonzero
+        const errorsValue = document.getElementById('pill-errors-value');
+        errorsValue.textContent = stats.parse_errors;
+        errorsValue.classList.toggle('warn', stats.parse_errors > 0);
+
+        // rejected pill — hidden when zero
+        const rejectedPill = document.getElementById('pill-rejected');
+        const rejectedValue = document.getElementById('pill-rejected-value');
+        if (rejectedPill && rejectedValue) {
             if (stats.rejected_connections > 0) {
-                rejectedEl.parentElement.style.display = '';
-                rejectedEl.textContent = stats.rejected_connections;
+                rejectedPill.style.display = '';
+                rejectedValue.textContent = stats.rejected_connections;
+                rejectedValue.classList.add('warn');
             } else {
-                rejectedEl.parentElement.style.display = 'none';
+                rejectedPill.style.display = 'none';
             }
         }
+
+        // listening pill port + empty-state hint
         if (stats.mllp_port) {
-            document.getElementById('mllp-port').textContent = stats.mllp_port;
+            document.getElementById('pill-port').textContent = stats.mllp_port;
+            const emptyPort = document.getElementById('mllp-port');
+            if (emptyPort) emptyPort.textContent = stats.mllp_port;
         }
     } catch (e) { }
+}
+
+// --- Health pills ---
+function setListeningPillState(state, tooltip) {
+    const pill = document.getElementById('pill-listening');
+    if (!pill) return;
+    pill.classList.remove('live', 'disconnected');
+    pill.classList.add(state);
+    pill.title = tooltip || (state === 'live' ? 'MLLP listener health' : 'WebSocket disconnected — reconnecting');
+}
+
+function formatRelativeTime(ms) {
+    if (ms < 1000) return 'just now';
+    if (ms < 60000) return `${Math.floor(ms / 1000)}s ago`;
+    if (ms < 3600000) return `${Math.floor(ms / 60000)}m ago`;
+    return `${Math.floor(ms / 3600000)}h ago`;
+}
+
+function pruneRateWindow() {
+    const cutoff = Date.now() - 60000;
+    while (rateWindow.length > 0 && rateWindow[0] < cutoff) {
+        rateWindow.shift();
+    }
+}
+
+function renderRateSpark() {
+    const buckets = new Array(10).fill(0);
+    const now = Date.now();
+    for (const t of rateWindow) {
+        const age = now - t;
+        if (age < 0 || age >= 60000) continue;
+        // idx 0 = oldest (60s ago), idx 9 = newest (most recent 6s)
+        const idx = Math.floor((60000 - age) / 6000);
+        const clamped = Math.max(0, Math.min(9, idx));
+        buckets[clamped]++;
+    }
+    const max = Math.max(...buckets, 1);
+    const w = 60;
+    const h = 18;
+    const pad = 1;
+    const step = w / (buckets.length - 1);
+    const points = buckets.map((v, i) => {
+        const x = i * step;
+        const y = h - (v / max) * (h - 2 * pad) - pad;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+    }).join(' ');
+    return `<polyline points="${points}" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round" />`;
+}
+
+function renderHealthPills() {
+    pruneRateWindow();
+
+    // rate pill — show only after first message
+    const ratePill = document.getElementById('pill-rate');
+    const rateValue = document.getElementById('pill-rate-value');
+    const rateSpark = document.getElementById('pill-rate-spark');
+    if (rateWindow.length > 0) {
+        ratePill.style.display = '';
+        rateValue.textContent = `${rateWindow.length}/min`;
+        rateSpark.innerHTML = renderRateSpark();
+    } else {
+        ratePill.style.display = 'none';
+    }
+
+    // last pill — show only after first message
+    const lastPill = document.getElementById('pill-last');
+    const lastValue = document.getElementById('pill-last-value');
+    if (lastMessageReceivedAt !== null) {
+        lastPill.style.display = '';
+        lastValue.textContent = formatRelativeTime(Date.now() - lastMessageReceivedAt);
+    } else {
+        lastPill.style.display = 'none';
+    }
 }
 
 // --- Rendering ---
@@ -1150,3 +1238,6 @@ autoscroll = !autoscroll;
 toggleAutoscroll();
 connectWs();
 setInterval(pollStats, 3000);
+setInterval(renderHealthPills, 1000);
+renderHealthPills();
+pollStats();

--- a/static/index.html
+++ b/static/index.html
@@ -21,15 +21,33 @@
             </svg>
             Harux
         </div>
-        <div class="stats-bar">
-            <div class="stat"><span class="stat-dot green" id="ws-dot"></span><span id="ws-status">Connecting...</span>
+        <div class="health" id="health-pills">
+            <div class="health-pill live" id="pill-listening" title="MLLP listener health">
+                <span class="dot" id="health-dot"></span>
+                <span class="label">listening</span>
+                <span class="value">:<span id="pill-port">2575</span></span>
             </div>
-            <div class="stat"><span class="stat-dot blue"></span>Messages: <span id="stat-total">0</span></div>
-            <div class="stat"><span class="stat-dot yellow"></span>Connections: <span id="stat-connections">0</span>
+            <div class="health-pill" id="pill-conns" title="Active TCP connections">
+                <span class="label">conns</span>
+                <span class="value" id="pill-conns-value">0 / 0</span>
             </div>
-            <div class="stat" style="display:none"><span class="stat-dot"
-                    style="background:var(--warning)"></span>Rejected: <span id="stat-rejected">0</span></div>
-            <div class="stat"><span class="stat-dot red"></span>Errors: <span id="stat-errors">0</span></div>
+            <div class="health-pill" id="pill-rate" style="display:none" title="Messages/min over last 60s">
+                <span class="label">rate</span>
+                <span class="value" id="pill-rate-value">0/min</span>
+                <svg class="spark" id="pill-rate-spark" viewBox="0 0 60 18" preserveAspectRatio="none"></svg>
+            </div>
+            <div class="health-pill" id="pill-last" style="display:none" title="Time since last message">
+                <span class="label">last</span>
+                <span class="value" id="pill-last-value">—</span>
+            </div>
+            <div class="health-pill" id="pill-rejected" style="display:none" title="Connections rejected over capacity">
+                <span class="label">rejected</span>
+                <span class="value" id="pill-rejected-value">0</span>
+            </div>
+            <div class="health-pill" id="pill-errors" title="Parse errors">
+                <span class="label">errors</span>
+                <span class="value" id="pill-errors-value">0</span>
+            </div>
         </div>
         <div class="header-actions">
             <button onclick="togglePause()" id="btn-pause" title="Pause live updates">⏸ Pause</button>

--- a/static/style.css
+++ b/static/style.css
@@ -64,42 +64,91 @@ header {
     height: 22px;
 }
 
-.stats-bar {
-    display: flex;
-    gap: 24px;
-    font-size: 12px;
-    font-family: var(--font-mono);
-    color: var(--text-secondary);
-}
-
-.stat {
+/* ── Health pills ───────────────────────────────────────────────────── */
+.health {
     display: flex;
     align-items: center;
     gap: 6px;
+    flex-wrap: nowrap;
+    overflow: hidden;
 }
 
-.stat-dot {
+.health-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 11px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.health-pill .label {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.health-pill .value {
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-weight: 500;
+}
+
+.health-pill .dot {
     width: 7px;
     height: 7px;
     border-radius: 50%;
-    display: inline-block;
-}
-
-.stat-dot.green {
     background: var(--success);
-    box-shadow: 0 0 6px var(--success);
+    box-shadow: 0 0 0 0 rgba(79, 185, 138, 0.55);
+    animation: health-pulse 1.8s ease-out infinite;
 }
 
-.stat-dot.blue {
-    background: var(--accent);
+.health-pill.live {
+    border-color: rgba(79, 185, 138, 0.35);
+    background: rgba(79, 185, 138, 0.08);
 }
 
-.stat-dot.red {
+.health-pill.live .value {
+    color: var(--success);
+}
+
+.health-pill.disconnected {
+    border-color: rgba(234, 99, 99, 0.35);
+    background: rgba(234, 99, 99, 0.08);
+}
+
+.health-pill.disconnected .value {
+    color: var(--error);
+}
+
+.health-pill.disconnected .dot {
     background: var(--error);
+    box-shadow: none;
+    animation: none;
 }
 
-.stat-dot.yellow {
-    background: var(--warning);
+.health-pill .value.warn {
+    color: var(--error);
+}
+
+.health-pill .spark {
+    width: 60px;
+    height: 18px;
+    color: var(--success);
+}
+
+@keyframes health-pulse {
+    0% {
+        box-shadow: 0 0 0 0 rgba(79, 185, 138, 0.5);
+    }
+
+    100% {
+        box-shadow: 0 0 0 6px rgba(79, 185, 138, 0);
+    }
 }
 
 .header-actions {


### PR DESCRIPTION
## Summary

Phase 2 of the v0.5.0 UI redesign — replaces the dot-and-counter `.stats-bar` with a row of pill-shaped health indicators. Implements item **1** of `CLAUDE_CODE_HANDOFF.md`. The MLLP listener is now first-class on the page.

### Pills (left to right)

| Pill | Source | Behavior |
|---|---|---|
| `listening :PORT` | `stats.mllp_port` | Green pulsing dot when WS connected; red static dot on disconnect. Replaces the previous `ws-status` text. Reconnect countdown moved to the pill's `title` tooltip. |
| `conns N / MAX` | `stats.active_connections` / `stats.max_connections` | Plain numeric. |
| `rate N/min` + sparkline | Client-side rolling 60-second `addMessage` timestamp window | Hidden until first message arrives. 60×18 inline SVG polyline, 10 buckets of 6 s, `var(--success)` stroke. |
| `last Ns ago` | Client-side `lastMessageReceivedAt` | Hidden until first message arrives. Refreshed every 1 s. Formats `2s ago`, `1m ago`, `12m ago`, `1h ago`. |
| `errors N` | `stats.parse_errors` | Value paints `var(--error)` when `> 0`. |
| `rejected N` | `stats.rejected_connections` | Hidden when zero — preserved from the old hidden 5th stat so the existing rejected-connections feature is not lost. |

The standalone "total messages" counter is dropped from the header; the rolling rate pill replaces it as the live-traffic signal. The internal `totalMessagesCount` JS variable stays because session-restore code reads it.

## Files

- **`static/index.html`** — rewrites lines 19–28 (`.stats-bar` block) as a `.health` row of `.health-pill` elements with stable IDs (`pill-listening`, `pill-conns`, `pill-rate`, `pill-last`, `pill-rejected`, `pill-errors`, plus `pill-port` for the listening-pill port value).
- **`static/style.css`** — drops the obsolete `.stats-bar`, `.stat`, `.stat-dot`, and `.stat-dot.green/blue/red/yellow` rules. Adds `.health`, `.health-pill`, `.health-pill.live`, `.health-pill.disconnected`, `.dot`, `.spark`, `.value.warn`, plus a `health-pulse` keyframe (1.8 s ease-out infinite expanding green ring around the dot).
- **`static/app.js`**:
  - New globals `rateWindow` (Date.now() buffer) and `lastMessageReceivedAt`.
  - `addMessage` pushes the timestamp + stamps `lastMessageReceivedAt`; the old `stat-total` write is gone.
  - WebSocket `onopen` / `onclose` / `onerror` call new helper `setListeningPillState('live' | 'disconnected', tooltip)` instead of mutating the removed `ws-dot` / `ws-status` elements.
  - `pollStats` writes to pill values, toggles `.warn` on errors, shows / hides the rejected pill, and updates both the listening-pill port and the empty-state hint port.
  - New `renderHealthPills()` runs every 1 s: prunes `rateWindow` to last 60 s, recomputes the rate count + sparkline, updates the relative-time label, and toggles visibility of `rate` / `last` pills based on whether traffic has been seen yet.
  - `cleared` event resets `rateWindow` + `lastMessageReceivedAt` so the rate / last pills hide again after `/api/clear`.

## Out of scope

- Throughput band (60-bar histogram) above the message list — that is **Phase 4 / item 2**, separate issue.
- Source rail rework, message-row redesign, detail-header restructure — Phases 3–6.

## Test plan

- [ ] CI: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test`
- [ ] Manual: launch `cargo run --release`, open the UI — `listening :2575`, `conns 0 / N`, `errors 0` pills visible; `rate` / `last` / `rejected` hidden until traffic.
- [ ] Manual: send a few messages with `./test.sh` — `rate` and `last` pills appear, sparkline animates, `last` updates each second.
- [ ] Manual: kill the server, watch the listening pill flip to red and tooltip read `Reconnecting in Ns…`.
- [ ] Manual: trigger a parse error — `errors` value paints red.
- [ ] Manual: hit a connection limit (set `MLLP_MAX_CONNECTIONS=1` and open a second connection) — `rejected` pill surfaces with red value.
- [ ] Manual: `POST /api/clear` — `rate` and `last` pills hide.

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)