### PR TITLE
Redesign Phase 3: two-line rows + time grouping + ACK chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **Typography** — adopted Inter (sans) and JetBrains Mono (mono) via Google Fonts; first phase of the v0.5.0 UI redesign (#86)
 - **Color palette** — refreshed dark theme: deeper backgrounds (`--bg-primary` `#0b0d12`, `--bg-secondary` `#131620`, `--bg-tertiary` `#1b1f2c`), cooler accent (`--accent` `#7aa2ff`), tuned success/error tones (`--success` `#4fb98a`, `--error` `#ea6363`) for higher contrast against the deeper canvas (#86)
 - **Top-bar health pills** — replaced the dot-and-counter `.stats-bar` with a row of pill-shaped status indicators: `listening :PORT` (green pulsing dot when WebSocket connected, red static when disconnected), `conns N / MAX`, `rate N/min` with a 60-second sparkline, `last Ns ago` (refreshed once per second), `errors N` (red value when nonzero). The previously hidden "rejected" stat is preserved as a hidden pill that surfaces only when `rejected_connections > 0`. The `total messages` counter was removed from the header; the rolling rate pill replaces it as the live-traffic signal (#92)
+- **Message rows — two-line layout** — dropped the dense 9-column grid (`12px 100px 90px 1fr 140px 60px 40px 24px 24px`) for a `[3 px source bar] [body] [actions]` layout. Row 1 carries `[type] [patient] [validation badge] [tags] [ACK chip]`; row 2 carries monospace `facility · source · N segs` with right-aligned time. The `Type / Facility / Patient / Date / Time / Segs / ACK` `.list-header` is removed (column titles are no longer needed). Actions column now shows the bookmark star only — the pin-for-diff icon was removed from the row and lives in the detail panel instead (#94)
+- **Time-bucket group headers** — messages are grouped under sticky headers: `Live` (last 30 s), `Last few minutes` (30 s – 5 min), `Earlier today`, `Yesterday`, and `MMM D` for older days. The header sticks to the top of the message list while scrolling so the bucket label stays visible (#94)
+- **ACK chips** — replaced the inline-styled `color:` ACK rendering with colored chip pills: `.msg-ack.aa` green, `.msg-ack.ae` red, `.msg-ack.ar` amber, `.msg-ack.none` muted. Easier to scan a column of failures at a glance (#94)
+- **Relative time on row 2** — messages in the `Live` and `Last few minutes` buckets show `Ns ago` / `Nm ago`; `Earlier today` shows `HH:mm:ss`; older messages show `MMM D HH:mm`. A 1-second tick refreshes the time labels in place without re-rendering the whole list (#94)
 
 ---
 
@@ -60,6 +64,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 | [`a14f0de`](https://github.com/Pappet/harux/commit/a14f0de20053257e6b9cd2b9e6063fc8e2daf8dc) | `fix:` resolve ISO-8859-1 charset encoding issues (#78) |
 | [`a6f1ce7`](https://github.com/Pappet/harux/commit/a6f1ce7e1e8deb5dbead3248e099423231b1cd09) | `feat(a11y):` ARIA labels, native buttons, global focus ring |
 | [`4554d90`](https://github.com/Pappet/harux/commit/4554d90488df2bd604f1017d024013cd08331f72) | `feat(ui):` top-bar health pills replace stats dots (#92) |
+| [`e658905`](https://github.com/Pappet/harux/commit/e658905e9faf919031eb267d8179c720d857e468) | `feat(ui):` two-line message rows with time grouping + ACK chips (#94) |
 | [`1993bcb`](https://github.com/Pappet/harux/commit/1993bcb07709460bce5d468c046be6e2f1db533c) | `feat(a11y):` keyboard navigation for message list rows |
 | [`f5c650a`](https://github.com/Pappet/harux/commit/f5c650aa025132a5a6e660092957fd3ad69099ec) | `feat(ui):` typography + color foundation for v0.5.0 redesign (#86) |
 

--- a/static/app.js
+++ b/static/app.js
@@ -389,6 +389,16 @@ function renderRateSpark() {
     return `<polyline points="${points}" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round" />`;
 }
 
+function tickRowRelativeTimes() {
+    const now = Date.now();
+    document.querySelectorAll('.message-row').forEach(row => {
+        const ts = row.dataset.received;
+        if (!ts) return;
+        const timeEl = row.querySelector('.msg-row2 .time');
+        if (timeEl) timeEl.textContent = rowTimeLabel({ received_at: ts }, now);
+    });
+}
+
 function renderHealthPills() {
     pruneRateWindow();
 
@@ -416,6 +426,154 @@ function renderHealthPills() {
 }
 
 // --- Rendering ---
+const MONTH_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function bucketKey(msg, now) {
+    const t = new Date(msg.received_at).getTime();
+    const age = now - t;
+    if (age < 30_000) return 'live';
+    if (age < 300_000) return 'recent';
+
+    const msgDate = new Date(t);
+    const today = new Date(now);
+    if (msgDate.toDateString() === today.toDateString()) return 'today';
+
+    const yesterday = new Date(now - 86_400_000);
+    if (msgDate.toDateString() === yesterday.toDateString()) return 'yesterday';
+
+    const y = msgDate.getFullYear();
+    const m = String(msgDate.getMonth() + 1).padStart(2, '0');
+    const d = String(msgDate.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+}
+
+function bucketLabel(key) {
+    if (key === 'live') return 'Live';
+    if (key === 'recent') return 'Last few minutes';
+    if (key === 'today') return 'Earlier today';
+    if (key === 'yesterday') return 'Yesterday';
+    const [y, m, d] = key.split('-').map(Number);
+    return `${MONTH_SHORT[m - 1]} ${d}`;
+}
+
+function rowTimeLabel(msg, now) {
+    const t = new Date(msg.received_at).getTime();
+    const age = now - t;
+    if (age < 60_000) return `${Math.max(0, Math.floor(age / 1000))}s ago`;
+    if (age < 300_000) return `${Math.floor(age / 60_000)}m ago`;
+
+    const msgDate = new Date(t);
+    const hh = String(msgDate.getHours()).padStart(2, '0');
+    const mn = String(msgDate.getMinutes()).padStart(2, '0');
+    const ss = String(msgDate.getSeconds()).padStart(2, '0');
+
+    const today = new Date(now);
+    if (msgDate.toDateString() === today.toDateString()) {
+        return `${hh}:${mn}:${ss}`;
+    }
+    const yesterday = new Date(now - 86_400_000);
+    if (msgDate.toDateString() === yesterday.toDateString()) {
+        return `Yest ${hh}:${mn}`;
+    }
+    return `${MONTH_SHORT[msgDate.getMonth()]} ${msgDate.getDate()} ${hh}:${mn}`;
+}
+
+function ackChipClass(code) {
+    if (code === 'AA') return 'msg-ack aa';
+    if (code === 'AE') return 'msg-ack ae';
+    if (code === 'AR') return 'msg-ack ar';
+    return 'msg-ack none';
+}
+
+function buildMessageRow(msg) {
+    const row = document.createElement('div');
+    let rowClass = 'message-row';
+    if (msg.id === selectedId) rowClass += ' selected';
+    if (msg.bookmarked) rowClass += ' bookmarked';
+
+    const srcKey = colorByPort ? msg.source_addr : (msg.source_addr ? msg.source_addr.split(':')[0] : '');
+    if (highlightedSource && srcKey !== highlightedSource) {
+        rowClass += ' dimmed';
+    }
+
+    row.className = rowClass;
+    row.dataset.id = msg.id;
+    row.tabIndex = 0;
+    row.setAttribute('role', 'button');
+    row.setAttribute('aria-label', `Message from ${msg.sending_facility || 'unknown'}, type ${msg.message_type || 'unknown'}, received ${msg.received_at}`);
+    row.onclick = () => selectMessage(msg.id);
+    row.onkeydown = (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            selectMessage(msg.id);
+        }
+    };
+
+    const srcColor = getSourceColor(msg.source_addr);
+
+    const typeHtml = msg.parse_error
+        ? `<span class="msg-type parse-error" title="${escAttr(msg.parse_error)}">⚠ PARSE ERROR</span>`
+        : `<span class="msg-type">${esc(msg.message_type || '—')}</span>`;
+
+    const warnCount = msg.validation_warning_count || 0;
+    const warnHtml = warnCount > 0
+        ? `<span class="msg-warning ${msg.has_segment_errors ? 'err' : 'warn'}" title="${warnCount} validation warning${warnCount > 1 ? 's' : ''}">⚠ ${warnCount}</span>`
+        : '';
+
+    const tagsArr = msg.tags || [];
+    let tagsHtml = '';
+    if (tagsArr.length > 0) {
+        const visible = tagsArr.slice(0, 2).map(t => `<span class="msg-tag-small">${esc(t)}</span>`).join('');
+        const overflow = tagsArr.length > 2
+            ? `<span class="msg-tag-small">+${tagsArr.length - 2}</span>`
+            : '';
+        tagsHtml = `<span class="msg-tags-list" style="margin-top:0">${visible}${overflow}</span>`;
+    }
+
+    const ackCode = (msg.ack_code || '').toUpperCase();
+    const ackHtml = ackCode
+        ? `<span class="${ackChipClass(ackCode)}">${esc(ackCode)}</span>`
+        : `<span class="msg-ack none">—</span>`;
+
+    const now = Date.now();
+    const timeLabel = rowTimeLabel(msg, now);
+    const segCount = msg.segment_count != null ? `${msg.segment_count} segs` : '—';
+    const facility = esc(msg.sending_facility || 'unknown');
+    const sourceAddr = esc(msg.source_addr || '');
+    const patient = esc(msg.patient_name || msg.patient_id || '—');
+
+    const bookmarkClass = msg.bookmarked ? 'msg-bookmark active' : 'msg-bookmark';
+    const bookmarkIcon = msg.bookmarked ? '★' : '☆';
+    const bookmarkLabel = msg.bookmarked ? 'Remove bookmark' : 'Add bookmark';
+
+    row.dataset.received = msg.received_at || '';
+
+    row.innerHTML = `
+        <div class="msg-source-bar" style="background:${srcColor}" title="${escAttr(msg.source_addr || '')}"></div>
+        <div class="msg-body">
+            <div class="msg-row1">
+                ${typeHtml}
+                <span class="msg-patient">${patient}</span>
+                ${warnHtml}
+                ${tagsHtml}
+                ${ackHtml}
+            </div>
+            <div class="msg-row2">
+                <span class="facility">${facility}</span>
+                <span class="sep">·</span>
+                <span class="src">${sourceAddr}</span>
+                <span class="sep">·</span>
+                <span class="segs">${segCount}</span>
+                <span class="time">${esc(timeLabel)}</span>
+            </div>
+        </div>
+        <div class="msg-actions">
+            <button class="${bookmarkClass}" aria-label="${bookmarkLabel}" onclick="toggleBookmark('${msg.id}', event)" title="Bookmark">${bookmarkIcon}</button>
+        </div>
+    `;
+    return row;
+}
+
 function renderMessageList() {
     const list = document.getElementById('message-list');
     const empty = document.getElementById('empty-state');
@@ -433,98 +591,29 @@ function renderMessageList() {
 
     if (filtered.length === 0) {
         empty.style.display = 'flex';
-        list.querySelectorAll('.message-row').forEach(r => r.remove());
+        list.querySelectorAll('.message-row, .group-header').forEach(r => r.remove());
         return;
     }
 
     empty.style.display = 'none';
 
     const fragment = document.createDocumentFragment();
+    const now = Date.now();
+    let currentBucket = null;
+
     for (const msg of filtered) {
-        const row = document.createElement('div');
-
-        let rowClass = 'message-row';
-        if (msg.id === selectedId) rowClass += ' selected';
-
-        const srcKey = colorByPort ? msg.source_addr : (msg.source_addr ? msg.source_addr.split(':')[0] : '');
-        if (highlightedSource && srcKey !== highlightedSource) {
-            rowClass += ' dimmed';
+        const bucket = bucketKey(msg, now);
+        if (bucket !== currentBucket) {
+            currentBucket = bucket;
+            const header = document.createElement('div');
+            header.className = 'group-header';
+            header.textContent = bucketLabel(bucket);
+            fragment.appendChild(header);
         }
-
-        row.className = rowClass;
-        row.dataset.id = msg.id;
-        row.tabIndex = 0;
-        row.setAttribute('role', 'button');
-        row.setAttribute('aria-label', `Message from ${msg.sending_facility || 'unknown'}, type ${msg.message_type || 'unknown'}, received ${msg.received_at}`);
-        row.onclick = () => selectMessage(msg.id);
-        row.onkeydown = (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                selectMessage(msg.id);
-            }
-        };
-
-        const time = new Date(msg.received_at);
-        const yyyy = time.getFullYear();
-        const mm = String(time.getMonth() + 1).padStart(2, '0');
-        const dd = String(time.getDate()).padStart(2, '0');
-        const hh = String(time.getHours()).padStart(2, '0');
-        const min = String(time.getMinutes()).padStart(2, '0');
-        const ss = String(time.getSeconds()).padStart(2, '0');
-        const timeStr = `${yyyy}-${mm}-${dd} ${hh}:${min}:${ss}`;
-        // Source color dot
-        const srcColor = getSourceColor(msg.source_addr);
-        const dotHtml = `<span class="source-dot" style="background:${srcColor};box-shadow:0 0 4px ${srcColor}" title="${escAttr(msg.source_addr)}"></span>`;
-
-        // Validation badge: red if missing segments (errors), yellow for field warnings only
-        const warnCount = msg.validation_warning_count || 0;
-        const warnCls = msg.has_segment_errors ? 'validation-badge error' : 'validation-badge';
-        const warnBadge = warnCount > 0
-            ? ` <span class="${warnCls}" title="${warnCount} validation warning${warnCount > 1 ? 's' : ''}">⚠ ${warnCount}</span>`
-            : '';
-        const typeHtml = msg.parse_error
-            ? `<span class="msg-type" style="color:var(--error)" title="${escAttr(msg.parse_error)}">⚠ PARSE ERROR</span>`
-            : `<span class="msg-type">${esc(msg.message_type)}${warnBadge}</span>`;
-
-        const tagsHtml = (msg.tags && msg.tags.length > 0)
-            ? `<div class="msg-tags-list">` + msg.tags.map(t => `<span class="msg-tag-small">${esc(t)}</span>`).join('') + `</div>`
-            : '';
-
-        let ackColor = '';
-        if (msg.ack_code === 'AA') ackColor = 'color: var(--success);';
-        else if (msg.ack_code === 'AE' || msg.ack_code === 'AR') ackColor = 'color: var(--error);';
-
-        const ackHtml = msg.ack_code
-            ? `<span class="msg-ack" style="${ackColor}">${esc(msg.ack_code)}</span>`
-            : `<span class="msg-ack">—</span>`;
-
-        const bookmarkClass = msg.bookmarked ? 'msg-bookmark active' : 'msg-bookmark';
-        const bookmarkIcon = msg.bookmarked ? '★' : '☆';
-        const bookmarkLabel = msg.bookmarked ? 'Remove bookmark' : 'Add bookmark';
-
-        const isPinned = diffPinnedMessage && diffPinnedMessage.id === msg.id;
-        const pinClass = isPinned ? 'msg-pin active' : 'msg-pin';
-        const pinIcon = isPinned ? '◉' : '◎';
-        const pinTitle = isPinned ? 'Unpin (diff reference)' : 'Pin as diff reference';
-
-        row.innerHTML = `
-            ${dotHtml}
-            <div style="display:flex; flex-direction:column; gap:2px; overflow:hidden;">
-                ${typeHtml}
-                ${tagsHtml}
-            </div>
-            <span class="msg-source">${esc(msg.sending_facility)}</span>
-            <span class="msg-patient">${esc(msg.patient_name || msg.patient_id || '—')}</span>
-            <span class="msg-time">${timeStr}</span>
-            <span class="msg-segs">${msg.segment_count}</span>
-            ${ackHtml}
-            <button class="${bookmarkClass}" aria-label="${bookmarkLabel}" onclick="toggleBookmark('${msg.id}', event)" title="Bookmark">${bookmarkIcon}</button>
-            <button class="${pinClass}" aria-label="${pinTitle}" onclick="toggleDiffPin('${msg.id}', event)" title="${pinTitle}">${pinIcon}</button>
-        `;
-        fragment.appendChild(row);
+        fragment.appendChild(buildMessageRow(msg));
     }
 
-    list.querySelectorAll('.message-row').forEach(r => r.remove());
+    list.querySelectorAll('.message-row, .group-header').forEach(r => r.remove());
     list.appendChild(fragment);
 
     if (autoscroll) {
@@ -1238,6 +1327,9 @@ autoscroll = !autoscroll;
 toggleAutoscroll();
 connectWs();
 setInterval(pollStats, 3000);
-setInterval(renderHealthPills, 1000);
+setInterval(() => {
+    renderHealthPills();
+    tickRowRelativeTimes();
+}, 1000);
 renderHealthPills();
 pollStats();

--- a/static/index.html
+++ b/static/index.html
@@ -67,17 +67,6 @@
                 <input type="text" id="search-input" placeholder="Filter: message type, patient, facility, ID..." />
             </div>
             <div class="source-legend" id="source-legend" style="display:none"></div>
-            <div class="list-header">
-                <span></span>
-                <span>Type</span>
-                <span>Facility</span>
-                <span>Patient</span>
-                <span>Date / Time</span>
-                <span>Segs</span>
-                <span>ACK</span>
-                <span></span>
-                <span></span>
-            </div>
             <div class="message-list" id="message-list">
                 <div class="empty-state" id="empty-state">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">

--- a/static/style.css
+++ b/static/style.css
@@ -279,17 +279,14 @@ body.resizing * {
     scrollbar-color: var(--bg-tertiary) transparent;
 }
 
+/* ── Message row — two-line layout ─────────────────────────────────── */
 .message-row {
     display: grid;
-    grid-template-columns: 12px 100px 90px 1fr 140px 60px 40px 24px 24px;
-    gap: 12px;
-    padding: 9px 16px;
+    grid-template-columns: 4px 1fr auto;
     border-bottom: 1px solid var(--border);
-    border-left: 3px solid transparent;
-    font-size: 12px;
     cursor: pointer;
-    transition: background 0.1s, opacity 0.15s, border-left-color 0.15s, outline 0.1s;
-    align-items: center;
+    position: relative;
+    transition: background 0.1s, opacity 0.15s, outline 0.1s;
 }
 
 .message-row:focus-visible {
@@ -302,12 +299,21 @@ body.resizing * {
 }
 
 .message-row:hover {
-    background: var(--bg-hover);
+    background: var(--bg-secondary);
 }
 
 .message-row.selected {
     background: var(--bg-tertiary);
-    border-left-color: var(--accent);
+}
+
+.message-row.selected::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--accent);
 }
 
 .message-row.new-flash {
@@ -324,57 +330,170 @@ body.resizing * {
     }
 }
 
+.msg-source-bar {
+    width: 3px;
+    align-self: stretch;
+    margin-left: 1px;
+}
+
+.msg-body {
+    padding: 11px 14px 11px 11px;
+    min-width: 0;
+}
+
+.msg-row1 {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 4px;
+}
+
 .msg-type {
     font-family: var(--font-mono);
     font-weight: 600;
+    font-size: 12px;
     color: var(--accent);
+    letter-spacing: -0.01em;
+    flex-shrink: 0;
 }
 
-.msg-source {
-    color: var(--text-secondary);
-    font-family: var(--font-mono);
-    font-size: 11px;
+.msg-type.parse-error {
+    color: var(--error);
 }
 
 .msg-patient {
     color: var(--text-primary);
-    white-space: nowrap;
+    font-weight: 500;
+    flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
 }
 
-.msg-time {
+.msg-row2 {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 11px;
     color: var(--text-muted);
     font-family: var(--font-mono);
-    font-size: 11px;
-    text-align: right;
 }
 
-.msg-segs {
+.msg-row2 .sep {
     color: var(--text-muted);
+    opacity: 0.6;
+}
+
+.msg-row2 .facility {
+    color: var(--text-secondary);
+}
+
+.msg-row2 .time {
+    margin-left: auto;
+}
+
+.msg-warning {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 1px 6px;
+    border-radius: 3px;
     font-family: var(--font-mono);
-    font-size: 11px;
-    text-align: right;
+    font-size: 10px;
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+.msg-warning.warn {
+    background: rgba(229, 165, 75, 0.12);
+    color: var(--warning);
+}
+
+.msg-warning.err {
+    background: rgba(234, 99, 99, 0.12);
+    color: var(--error);
 }
 
 .msg-ack {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px;
+    border-radius: 3px;
     font-family: var(--font-mono);
-    font-size: 11px;
-    text-align: center;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    flex-shrink: 0;
 }
 
-.list-header {
-    display: grid;
-    grid-template-columns: 12px 100px 90px 1fr 140px 60px 40px 24px 24px;
-    gap: 12px;
-    padding: 7px 16px;
+.msg-ack.aa {
+    background: rgba(79, 185, 138, 0.12);
+    color: var(--success);
+}
+
+.msg-ack.ae {
+    background: rgba(234, 99, 99, 0.12);
+    color: var(--error);
+}
+
+.msg-ack.ar {
+    background: rgba(229, 165, 75, 0.14);
+    color: var(--warning);
+}
+
+.msg-ack.none {
+    background: var(--bg-tertiary);
+    color: var(--text-muted);
+}
+
+.msg-actions {
+    display: flex;
+    align-items: center;
+    padding-right: 10px;
+    opacity: 0;
+    transition: opacity 0.12s;
+}
+
+.message-row:hover .msg-actions,
+.message-row.selected .msg-actions,
+.message-row.bookmarked .msg-actions {
+    opacity: 1;
+}
+
+/* ── Time-bucket group headers ─────────────────────────────────────── */
+.group-header {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px 6px;
+    background: var(--bg-primary);
+    color: var(--text-muted);
     font-size: 10px;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--text-muted);
-    background: var(--bg-secondary);
-    border-bottom: 1px solid var(--border);
+    letter-spacing: 0.08em;
     font-weight: 600;
+    border-bottom: 1px solid var(--border);
+}
+
+.group-header::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--border);
+}
+
+.group-header .count {
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+    opacity: 0.7;
+    font-weight: 500;
+    letter-spacing: 0;
+    text-transform: none;
 }
 
 .empty-state {


### PR DESCRIPTION
## Summary

Phase 3 of the v0.5.0 UI redesign — the dense 9-column grid is gone. Implements items **4**, **5**, **6**, and the row-side of item **7** from `CLAUDE_CODE_HANDOFF.md`. The largest single perceived improvement of the entire redesign.

### Item 4 — Two-line row layout

- New grid: `4px 1fr auto` (`[3 px source bar] [body] [actions]`).
- **Row 1**: `[type] [patient (flex)] [validation badge] [tags] [ACK chip]`. Patient ellipsis-truncates on overflow.
- **Row 2**: `[facility] · [source addr] · [N segs] [time]` in monospace. Time right-aligned.
- 3 px source bar runs the full row height — replaces the 12 px source-dot cell.
- Selected state uses absolute-positioned `::before` 2 px accent left border instead of `border-left-color` flip → no row-content shift on selection (fixes the old flicker for free).
- Actions column = bookmark star only. Pin-for-diff is gone from the row (Item 7 partial).
- The `.list-header` "Type / Facility / Patient / Date / Time / Segs / ACK" row in `static/index.html` is removed — column titles no longer needed.

### Item 5 — Sticky time-bucket headers

`bucketKey(msg, now)` groups messages into:

| Key | Range | Header label |
|---|---|---|
| `live` | last 30 s | **Live** |
| `recent` | 30 s – 5 min | **Last few minutes** |
| `today` | same calendar day, > 5 min | **Earlier today** |
| `yesterday` | previous day | **Yesterday** |
| `YYYY-MM-DD` | older | **MMM D** (e.g. `May 7`) |

`renderMessageList` walks the filtered array and emits a `.group-header` element whenever the bucket changes. Header is `position: sticky; top: 0; z-index: 2;` with a trailing divider via `::after`.

### Item 6 — ACK chips

Replaces the inline-styled `color:` rendering with chip pills:

| ACK | Class | Style |
|---|---|---|
| AA | `.msg-ack.aa` | green tinted bg + `var(--success)` text |
| AE | `.msg-ack.ae` | red tinted bg + `var(--error)` text |
| AR | `.msg-ack.ar` | amber tinted bg + `var(--warning)` text |
| (none) | `.msg-ack.none` | muted bg + `var(--text-muted)` text |

A column of failures pops at a glance.

### Item 7 (partial) — Pin removed from row

The `<button class="msg-pin">` block in `renderMessageList` is gone. `toggleDiffPin` is unchanged and still works from the detail panel — that is now the single pin entry point.

### Bonus — relative-time tick

Each row carries `data-received`. A 1-second tick (wired into the existing `renderHealthPills` interval) refreshes only the `.msg-row2 .time` text in place — no full re-render. Bucket re-flow happens at the next full render (next addMessage or filter change).

## Files

- `static/index.html` — removes the `.list-header` block (lines 70–80).
- `static/style.css` — drops `.message-row` 9-col grid, `.msg-source`, `.msg-time`, `.msg-segs`, `.list-header`. Adds `.msg-source-bar`, `.msg-body`, `.msg-row1`, `.msg-row2`, `.msg-warning.warn/.err`, `.msg-ack.aa/.ae/.ar/.none`, `.msg-actions`, `.group-header`.
- `static/app.js` — extracts `buildMessageRow(msg)` and adds `bucketKey`, `bucketLabel`, `rowTimeLabel`, `ackChipClass`, `tickRowRelativeTimes` helpers. `renderMessageList` walks filtered messages and emits group headers + rows.

## Out of scope

- Source rail with always-visible chips — Phase 4.
- Throughput band — Phase 4.
- Detail-panel restructure (type chip + human title + meta + actions row) — Phase 5.
- Validation summary banner — Phase 5.
- Empty-state CLI hint — Phase 6.

## Test plan

- [ ] CI: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test`
- [ ] Manual: send a few messages with `./test.sh` — rows render two lines, source bar colored, ACK chip green for AA, amber for AR, red for AE.
- [ ] Manual: scroll the list — group headers stick to the top of the message-list pane.
- [ ] Manual: wait — `Live` bucket time labels tick (`2s ago` → `5s ago` → `12s ago`); after 30 s the message moves into `Last few minutes` on next render.
- [ ] Manual: select a row — accent left border appears via `::before`; row content does not shift horizontally.
- [ ] Manual: click bookmark — star toggles; row stays on screen, action column visible.
- [ ] Manual: confirm there is **no** pin icon in the row; pin is reachable only from the detail panel.
- [ ] Manual: filter via search box, validation filter, bookmark filter — rows still respect filters and group headers re-flow.
- [ ] Manual: parse-error messages render `⚠ PARSE ERROR` in red on row 1.

Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)