### PR TITLE
Redesign Phase 4: source rail + throughput band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **Time-bucket group headers** — messages are grouped under sticky headers: `Live` (last 30 s), `Last few minutes` (30 s – 5 min), `Earlier today`, `Yesterday`, and `MMM D` for older days. The header sticks to the top of the message list while scrolling so the bucket label stays visible (#94)
 - **ACK chips** — replaced the inline-styled `color:` ACK rendering with colored chip pills: `.msg-ack.aa` green, `.msg-ack.ae` red, `.msg-ack.ar` amber, `.msg-ack.none` muted. Easier to scan a column of failures at a glance (#94)
 - **Relative time on row 2** — messages in the `Live` and `Last few minutes` buckets show `Ns ago` / `Nm ago`; `Earlier today` shows `HH:mm:ss`; older messages show `MMM D HH:mm`. A 1-second tick refreshes the time labels in place without re-rendering the whole list (#94)
+- **Always-visible source rail** — the source legend (previously hidden until toggled) is now a permanent rail above the message list. Each source renders as a `.source-chip` with colored dot, host (or `host:port`), and per-source message count. Click toggles `highlightedSource` and dims non-matching rows. The rail scrolls horizontally when chips overflow, with hidden scrollbars (#96)
+- **Color by Port moved to overflow menu** — the `Color by Port` toggle is no longer inline with the source chips. It lives in a `<details>` overflow popover (⋯) at the right edge of the rail, freeing the rail for scannable source identification (#96)
+- **Throughput band** — a new row between the source rail and the message list shows four counters (`total`, `per min`, `warnings`, `errors`) plus a 60-bar histogram representing the last 60 seconds of message arrivals. Bars rotate every second; opacity ramps from 0.4 (oldest) to 1.0 (newest). `warnings` paints amber when nonzero, `errors` paints red. Backed by a `rateBuckets` ring buffer that is incremented by `addMessage` and rotated by a 1-second interval (#96)
 
 ---
 
@@ -65,6 +68,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 | [`a6f1ce7`](https://github.com/Pappet/harux/commit/a6f1ce7e1e8deb5dbead3248e099423231b1cd09) | `feat(a11y):` ARIA labels, native buttons, global focus ring |
 | [`4554d90`](https://github.com/Pappet/harux/commit/4554d90488df2bd604f1017d024013cd08331f72) | `feat(ui):` top-bar health pills replace stats dots (#92) |
 | [`e658905`](https://github.com/Pappet/harux/commit/e658905e9faf919031eb267d8179c720d857e468) | `feat(ui):` two-line message rows with time grouping + ACK chips (#94) |
+| [`3e49222`](https://github.com/Pappet/harux/commit/3e49222e15524144e94b7c780cf1cb03e2a0b21a) | `feat(ui):` always-visible source rail + 60-bar throughput band (#96) |
 | [`1993bcb`](https://github.com/Pappet/harux/commit/1993bcb07709460bce5d468c046be6e2f1db533c) | `feat(a11y):` keyboard navigation for message list rows |
 | [`f5c650a`](https://github.com/Pappet/harux/commit/f5c650aa025132a5a6e660092957fd3ad69099ec) | `feat(ui):` typography + color foundation for v0.5.0 redesign (#86) |
 

--- a/static/app.js
+++ b/static/app.js
@@ -103,7 +103,9 @@ function renderSourceLegend() {
     if (seenSources.size === 0) {
         container.innerHTML = `
             <span class="label">Sources</span>
-            <span class="source-rail-empty">none yet</span>
+            <div class="source-rail-chips">
+                <span class="source-rail-empty">none yet</span>
+            </div>
             <details class="source-rail-overflow">
                 <summary title="Source options">⋯</summary>
                 <div class="popover">
@@ -144,7 +146,7 @@ function renderSourceLegend() {
 
     container.innerHTML = `
         <span class="label">Sources</span>
-        ${chipsHtml}
+        <div class="source-rail-chips">${chipsHtml}</div>
         <details class="source-rail-overflow">
             <summary title="Source options">⋯</summary>
             <div class="popover">

--- a/static/app.js
+++ b/static/app.js
@@ -28,6 +28,11 @@ let totalMessagesCount = 0;
 const rateWindow = [];               // Date.now() timestamps within last 60 s
 let lastMessageReceivedAt = null;    // Date.now() of most recent addMessage
 
+// Throughput-band state: 60-second ring buffer of message counts (one per second).
+// The rightmost bucket is "now"; it is incremented by addMessage and rotated
+// every second by rotateRateBuckets.
+const rateBuckets = new Array(60).fill(0);
+
 // Segment diff state
 let diffPinnedMessage = null; // the reference message pinned for comparison
 let diffIgnoreDynamic = false;
@@ -86,42 +91,70 @@ function toggleHighlightSource(label) {
     saveSession();
 }
 
+function srcLabelFor(addr) {
+    if (!addr) return '';
+    return colorByPort ? addr : addr.split(':')[0];
+}
+
 function renderSourceLegend() {
-    const container = document.getElementById('source-legend');
+    const container = document.getElementById('source-rail');
     if (!container) return;
+
     if (seenSources.size === 0) {
-        container.style.display = 'none';
+        container.innerHTML = `
+            <span class="label">Sources</span>
+            <span class="source-rail-empty">none yet</span>
+            <details class="source-rail-overflow">
+                <summary title="Source options">⋯</summary>
+                <div class="popover">
+                    <label>
+                        <input type="checkbox" onchange="toggleColorByPort(event)" ${colorByPort ? 'checked' : ''}>
+                        Color by Port
+                    </label>
+                </div>
+            </details>
+        `;
         return;
     }
-    container.style.display = 'flex';
+
+    // Build per-source counts from the messages array.
+    const counts = new Map();
+    for (const m of messages) {
+        const label = srcLabelFor(m.source_addr);
+        if (!label) continue;
+        counts.set(label, (counts.get(label) || 0) + 1);
+    }
 
     const uniqueLabels = new Set();
-    seenSources.forEach(addr => {
-        uniqueLabels.add(colorByPort ? addr : addr.split(':')[0]);
-    });
-
+    seenSources.forEach(addr => uniqueLabels.add(srcLabelFor(addr)));
     const sortedLabels = Array.from(uniqueLabels).sort();
 
-    let html = sortedLabels.map(label => {
+    const chipsHtml = sortedLabels.map(label => {
         const color = SOURCE_PALETTE[hashString(label) % SOURCE_PALETTE.length];
-        const isHighlighted = highlightedSource === label;
+        const isActive = highlightedSource === label;
         const isDimmed = highlightedSource && highlightedSource !== label;
-        const classes = `source-legend-item${isHighlighted ? ' highlighted' : ''}${isDimmed ? ' dimmed' : ''}`;
-
+        const classes = `source-chip${isActive ? ' active' : ''}${isDimmed ? ' dimmed' : ''}`;
+        const num = counts.get(label) || 0;
         return `<span class="${classes}" onclick="toggleHighlightSource('${escAttr(escJS(label))}')">
-            <span class="source-dot" style="background:${color};box-shadow:0 0 4px ${color}"></span>
+            <span class="dot" style="background:${color};color:${color}"></span>
             ${esc(label)}
+            <span class="num">${num}</span>
         </span>`;
     }).join('');
 
-    html += `
-        <label class="theme-toggle" style="margin-left:auto; cursor:pointer; display:flex; align-items:center; gap:8px; color:var(--text-muted)">
-            <input type="checkbox" onchange="toggleColorByPort(event)" style="display:none" ${colorByPort ? 'checked' : ''}>
-            <span class="toggle-slider"></span>
-            Color by Port
-        </label>
+    container.innerHTML = `
+        <span class="label">Sources</span>
+        ${chipsHtml}
+        <details class="source-rail-overflow">
+            <summary title="Source options">⋯</summary>
+            <div class="popover">
+                <label>
+                    <input type="checkbox" onchange="toggleColorByPort(event)" ${colorByPort ? 'checked' : ''}>
+                    Color by Port
+                </label>
+            </div>
+        </details>
     `;
-    container.innerHTML = html;
 }
 
 // --- Session Persistence ---
@@ -212,11 +245,14 @@ function connectWs() {
             pendingMessages = [];
             totalMessagesCount = 0;
             rateWindow.length = 0;
+            rateBuckets.fill(0);
             lastMessageReceivedAt = null;
             selectedId = null;
             selectedMessage = null;
             renderMessageList();
+            renderSourceLegend();
             renderHealthPills();
+            renderThroughputBand();
             document.getElementById('detail-content').innerHTML = '<div class="empty-state"><p>No message selected</p></div>';
             document.getElementById('detail-title').textContent = 'Select a message';
             document.getElementById('detail-meta').textContent = '';
@@ -262,6 +298,7 @@ function addMessage(summary) {
     totalMessagesCount++;
     const now = Date.now();
     rateWindow.push(now);
+    rateBuckets[rateBuckets.length - 1]++;
     lastMessageReceivedAt = now;
     if (!paused) {
         scheduleRender();
@@ -284,6 +321,7 @@ function flushAndRender() {
     }
     renderMessageList();
     renderSourceLegend();
+    renderThroughputBand();
 }
 
 async function loadMessages() {
@@ -298,6 +336,7 @@ async function loadMessages() {
         }
         renderMessageList();
         renderSourceLegend();
+        renderThroughputBand();
     } catch (e) {
         console.error('Failed to load messages:', e);
     }
@@ -387,6 +426,54 @@ function renderRateSpark() {
         return `${x.toFixed(1)},${y.toFixed(1)}`;
     }).join(' ');
     return `<polyline points="${points}" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round" />`;
+}
+
+// --- Throughput band ---
+function rotateRateBuckets() {
+    rateBuckets.shift();
+    rateBuckets.push(0);
+}
+
+function renderThroughputBand() {
+    const totalEl = document.getElementById('rate-total');
+    const perminEl = document.getElementById('rate-permin');
+    const warnEl = document.getElementById('rate-warnings');
+    const errEl = document.getElementById('rate-errors');
+    const bars = document.getElementById('rate-bars');
+    if (!totalEl || !bars) return;
+
+    const total = messages.length + pendingMessages.length;
+    const perMin = rateWindow.length;
+
+    let warnings = 0;
+    let errors = 0;
+    for (const m of messages) {
+        if (m.has_segment_errors) errors++;
+        else if ((m.validation_warning_count || 0) > 0) warnings++;
+    }
+
+    totalEl.textContent = total;
+    perminEl.textContent = perMin;
+    warnEl.textContent = warnings;
+    warnEl.classList.toggle('warn', warnings > 0);
+    errEl.textContent = errors;
+    errEl.classList.toggle('err', errors > 0);
+
+    const n = rateBuckets.length;
+    const w = 200;
+    const h = 30;
+    const barW = w / n;
+    const max = Math.max(...rateBuckets, 1);
+    let html = '';
+    for (let i = 0; i < n; i++) {
+        const v = rateBuckets[i];
+        const barH = (v / max) * (h - 2);
+        const x = i * barW + 0.25;
+        const y = h - barH;
+        const opacity = 0.4 + (i / (n - 1 || 1)) * 0.6;
+        html += `<rect x="${x.toFixed(2)}" y="${y.toFixed(2)}" width="${(barW - 0.5).toFixed(2)}" height="${barH.toFixed(2)}" rx="0.5" opacity="${opacity.toFixed(2)}"/>`;
+    }
+    bars.innerHTML = html;
 }
 
 function tickRowRelativeTimes() {
@@ -1328,8 +1415,12 @@ toggleAutoscroll();
 connectWs();
 setInterval(pollStats, 3000);
 setInterval(() => {
+    rotateRateBuckets();
     renderHealthPills();
     tickRowRelativeTimes();
+    renderThroughputBand();
 }, 1000);
 renderHealthPills();
+renderSourceLegend();
+renderThroughputBand();
 pollStats();

--- a/static/index.html
+++ b/static/index.html
@@ -66,7 +66,28 @@
             <div class="search-bar">
                 <input type="text" id="search-input" placeholder="Filter: message type, patient, facility, ID..." />
             </div>
-            <div class="source-legend" id="source-legend" style="display:none"></div>
+            <div class="source-rail" id="source-rail"></div>
+            <div class="rate-band" id="rate-band">
+                <div class="stat">
+                    <span class="v" id="rate-total">0</span>
+                    <span class="l">total</span>
+                </div>
+                <div class="stat">
+                    <span class="v" id="rate-permin">0</span>
+                    <span class="l">per min</span>
+                </div>
+                <div class="stat">
+                    <span class="v" id="rate-warnings">0</span>
+                    <span class="l">warnings</span>
+                </div>
+                <div class="stat">
+                    <span class="v" id="rate-errors">0</span>
+                    <span class="l">errors</span>
+                </div>
+                <div class="spark-wrap">
+                    <svg class="bars" id="rate-bars" viewBox="0 0 200 30" preserveAspectRatio="none"></svg>
+                </div>
+            </div>
             <div class="message-list" id="message-list">
                 <div class="empty-state" id="empty-state">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">

--- a/static/style.css
+++ b/static/style.css
@@ -540,11 +540,23 @@ body.resizing * {
     border-bottom: 1px solid var(--border);
     font-size: 11px;
     color: var(--text-muted);
+    /* overflow stays visible so the overflow popover can escape; chips scroll
+       inside .source-rail-chips instead. */
+    position: relative;
+    z-index: 3;
+}
+
+.source-rail-chips {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+    min-width: 0;
     overflow-x: auto;
     scrollbar-width: none;
 }
 
-.source-rail::-webkit-scrollbar {
+.source-rail-chips::-webkit-scrollbar {
     display: none;
 }
 
@@ -607,8 +619,8 @@ body.resizing * {
 
 /* Overflow menu (Color by Port toggle) */
 .source-rail-overflow {
-    margin-left: auto;
     position: relative;
+    flex-shrink: 0;
 }
 
 .source-rail-overflow > summary {
@@ -648,7 +660,7 @@ body.resizing * {
     border-radius: 6px;
     padding: 8px 10px;
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
-    z-index: 5;
+    z-index: 50;
     white-space: nowrap;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -530,43 +530,189 @@ body.resizing * {
     flex-shrink: 0;
 }
 
-/* Source legend bar */
-.source-legend {
+/* ── Source rail (always visible) ──────────────────────────────────── */
+.source-rail {
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
     gap: 10px;
-    padding: 6px 16px;
+    padding: 8px 14px;
     background: var(--bg-secondary);
     border-bottom: 1px solid var(--border);
     font-size: 11px;
-    font-family: var(--font-mono);
-    color: var(--text-secondary);
-    align-items: center;
+    color: var(--text-muted);
+    overflow-x: auto;
+    scrollbar-width: none;
 }
 
-.source-legend-item {
+.source-rail::-webkit-scrollbar {
+    display: none;
+}
+
+.source-rail .label {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 10px;
+    color: var(--text-muted);
+    opacity: 0.7;
+    white-space: nowrap;
+}
+
+.source-rail .source-rail-empty {
+    font-style: italic;
+    opacity: 0.6;
+}
+
+.source-chip {
     display: inline-flex;
     align-items: center;
-    gap: 5px;
-    white-space: nowrap;
+    gap: 6px;
+    padding: 3px 8px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-secondary);
     cursor: pointer;
-    transition: opacity 0.15s, background-color 0.15s, border-color 0.15s;
-    padding: 2px 6px;
-    border-radius: 4px;
-    border: 1px solid transparent;
+    white-space: nowrap;
+    transition: background 0.12s, color 0.12s, border-color 0.12s, opacity 0.12s;
 }
 
-.source-legend-item:hover {
-    background-color: var(--bg-tertiary);
+.source-chip:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
 }
 
-.source-legend-item.dimmed {
+.source-chip.active {
+    background: var(--bg-hover);
+    border-color: var(--text-muted);
+    color: var(--text-primary);
+}
+
+.source-chip.dimmed {
     opacity: 0.4;
 }
 
-.source-legend-item.highlighted {
-    background-color: var(--bg-tertiary);
-    border-color: var(--border);
+.source-chip .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    box-shadow: 0 0 6px currentColor;
+}
+
+.source-chip .num {
+    color: var(--text-muted);
+    font-size: 10px;
+}
+
+/* Overflow menu (Color by Port toggle) */
+.source-rail-overflow {
+    margin-left: auto;
+    position: relative;
+}
+
+.source-rail-overflow > summary {
+    list-style: none;
+    cursor: pointer;
+    width: 24px;
+    height: 22px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    color: var(--text-muted);
+    font-size: 14px;
+    user-select: none;
+}
+
+.source-rail-overflow > summary::-webkit-details-marker {
+    display: none;
+}
+
+.source-rail-overflow > summary:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+
+.source-rail-overflow[open] > summary {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+
+.source-rail-overflow .popover {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 4px);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 8px 10px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+    z-index: 5;
+    white-space: nowrap;
+}
+
+.source-rail-overflow .popover label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+
+/* ── Throughput band ───────────────────────────────────────────────── */
+.rate-band {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 8px 14px 10px;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border);
+}
+
+.rate-band .stat {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 42px;
+}
+
+.rate-band .stat .v {
+    font-family: var(--font-mono);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+}
+
+.rate-band .stat .v.warn {
+    color: var(--warning);
+}
+
+.rate-band .stat .v.err {
+    color: var(--error);
+}
+
+.rate-band .stat .l {
+    font-size: 10px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.rate-band .spark-wrap {
+    flex: 1;
+    height: 30px;
+    position: relative;
+    min-width: 80px;
+}
+
+.rate-band svg.bars {
+    width: 100%;
+    height: 100%;
+    display: block;
+    fill: var(--accent);
 }
 
 /* Custom CSS Toggle Switch */


### PR DESCRIPTION
## Summary

Phase 4 of the v0.5.0 UI redesign — adds two new rows between the search toolbar and the message list. Implements items **2** (throughput band) and **3** (source rail) of `CLAUDE_CODE_HANDOFF.md`.

```
[ search toolbar ]
[ source rail   ]   ← Item 3
[ throughput    ]   ← Item 2
[ messages       ]
```

### Item 3 — Source rail (always visible)

- Old `.source-legend` (rendered `display:none` until toggled) is replaced with a permanent `.source-rail`.
- Each source renders as `.source-chip` with colored dot, host (or `host:port` when `colorByPort` is on), and per-source count derived from `messages.filter(...).length`.
- Click toggles `highlightedSource` — non-matching `.message-row.dimmed` behavior unchanged.
- `.source-chip.active` and `.source-chip.dimmed` replace the old `.source-legend-item.highlighted/.dimmed`.
- Horizontal scroll when chips overflow; scrollbars hidden (`scrollbar-width: none`, `::-webkit-scrollbar { display: none }`).

### Item 3 — Color by Port → overflow menu

- The toggle is moved out of the chip row into a `<details>` popover (⋯ at the right edge). Native `<details>` avoids click-outside-to-close JS; `summary::-webkit-details-marker { display: none }` strips the disclosure triangle.

### Item 2 — Throughput band

- Four counters: `total` (`messages.length + pendingMessages.length`), `per min` (`rateWindow.length`, same as the rate pill), `warnings` (validation warnings without segment errors), `errors` (segment errors). `.v.warn` / `.v.err` paint `--warning` / `--error` when nonzero.
- 60-bar SVG histogram of arrivals over the last minute. Backed by `rateBuckets = new Array(60).fill(0)`:
  - `addMessage` increments `rateBuckets[length - 1]` alongside the existing `rateWindow.push`.
  - `rotateRateBuckets()` shifts the ring once per second from the same 1 s interval as the health pills.
- Opacity ramps 0.4 → 1.0 left to right (matches mockup pattern). Rect fill from `var(--accent)`.

## Files

- `static/index.html` — adds `<div class="source-rail" id="source-rail">` and `<div class="rate-band" id="rate-band">` blocks above the message list. Removes the old `<div class="source-legend" id="source-legend" style="display:none">`.
- `static/style.css` — drops `.source-legend`, `.source-legend-item`, `.source-legend-item.highlighted/.dimmed`. Adds `.source-rail`, `.source-rail .label`, `.source-rail-empty`, `.source-chip`, `.source-chip:hover`, `.source-chip.active`, `.source-chip.dimmed`, `.source-chip .dot`, `.source-chip .num`, `.source-rail-overflow`, `.source-rail-overflow .popover`, `.rate-band`, `.rate-band .stat`, `.rate-band .stat .v`, `.rate-band .stat .v.warn/.err`, `.rate-band .stat .l`, `.rate-band .spark-wrap`, `.rate-band svg.bars`.
- `static/app.js`:
  - New `rateBuckets` global; `srcLabelFor(addr)` helper.
  - `addMessage` and `cleared` event update `rateBuckets`.
  - `renderSourceLegend` rewritten to emit the new rail + per-source counts + overflow popover.
  - New `rotateRateBuckets`, `renderThroughputBand`.
  - 1 s tick now runs `rotateRateBuckets → renderHealthPills → tickRowRelativeTimes → renderThroughputBand`.
  - `flushAndRender` and `loadMessages` call `renderThroughputBand` so counters reflect the current buffer immediately.

## Out of scope

- Detail-panel restructure — Phase 5.
- Validation summary banner, typical-segments checklist — Phase 5.
- Empty-state CLI hint — Phase 6.
- Sticky time-bucket headers — already shipped in Phase 3.
- Health pills — already shipped in Phase 2.

## Test plan

- [ ] CI: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test`
- [ ] Manual: launch `cargo run --release` — empty rail shows `Sources · none yet`; rate band shows `total 0 / per min 0 / warnings 0 / errors 0`.
- [ ] Manual: send messages with `./test.sh` — chips appear with counts, count badges increment, bars climb.
- [ ] Manual: click a chip — `.active` styling, non-matching rows `.dimmed`. Click again to clear.
- [ ] Manual: click the ⋯ overflow → `Color by Port` toggle opens. Toggle on, chip labels switch from `host` to `host:port`, count groupings adjust.
- [ ] Manual: trigger a parse error — `errors` counter goes red.
- [ ] Manual: trigger a validation warning — `warnings` counter goes amber (errors still 0 if segment present).
- [ ] Manual: hit `/api/clear` — chips empty, counters reset to 0, bars flatten.
- [ ] Manual: scroll the source rail when 6+ sources are present — horizontal scroll works without visible scrollbar.

Closes #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)