### PR TITLE
Redesign Phase 6: empty state + polish pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **Typical segments checklist** — wrapped in a card (`.seg-checklist`) and each pill carries an explicit symbol: `✓` present, `⚠` flagged, `✕` required-but-missing, blank for absent-and-optional (#98)
 - **Validation summary banner** — replaced the bulleted `.validation-warnings-panel` with a one-line summary banner at the top of the segments view: `⚠ 2 validation warnings · required field missing in PD1-3, expected segment not sent: OBX`. The full bulleted list is preserved as a collapsible `<details>` body (#98)
 - **Field rows show description inline** — the field-dictionary description is no longer hover-only. It renders as a `.desc-text` sub-line under the field index (e.g. `PID-5 / Patient name`). Rows that triggered a `MISSING_FIELD` warning are tinted amber and gain a `⚠ required` suffix on the value cell. The hover-tooltip CSS for `.field-idx.has-tooltip` is removed in favor of the inline line (#98)
+- **Empty-state CLI hint** — the message-list empty state is now an `.empty-card` with a tray icon, the live listening port, "No messages received yet", and a copy-able `mllp-send` snippet whose port is wired to `stats.mllp_port` so it tracks the actual listener (#101)
+- **Detail-panel empty state** — the cold "Click a message to view details" placeholder becomes a matching `.empty-card` with a small document icon and a one-line hint about what each tab shows (#101)
+- **Search shortcut** — `Cmd+K` (or `Ctrl+K` on non-Mac) focuses the filter input. The hint chip (`⌘K` / `^K`) sits inside the search field and fades out on focus or when the user is already typing (#101)
+- **Search bar polish** — the filter input gains a leading magnifier icon and the placeholder now hints at `has:errors` operators (#101)
+- **Tag-chip remove control** — replaced the `×` text glyph with the same lucide-style x SVG used elsewhere; the chip itself is now a pill-shaped `.msg-tag` with an inline-grid hover halo around the remove control (#101)
+- **Validation summary chevron** — the trailing `▸` text glyph is replaced with the chevron SVG; CSS rotates it 90° when the `<details>` is open (#101)
+- **`tr.warn` "required" suffix** — dropped the `⚠` glyph; the suffix now renders as a small uppercase `required` chip in `--warning` color (#101)
+- **Diff tab affordance** — the right-aligned Diff tab gains a chevron icon and reads `Diff vs pinned` so it visually announces "leads to the comparison view" (#101)
+- **Source-chip count badge + tab font weight** — source-chip count badges get a tinted background so they pop against the chip body; active tabs render at `font-weight: 600` for a clearer reading rhythm (#101)
 
 ---
 
@@ -75,6 +84,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 | [`e658905`](https://github.com/Pappet/harux/commit/e658905e9faf919031eb267d8179c720d857e468) | `feat(ui):` two-line message rows with time grouping + ACK chips (#94) |
 | [`3e49222`](https://github.com/Pappet/harux/commit/3e49222e15524144e94b7c780cf1cb03e2a0b21a) | `feat(ui):` always-visible source rail + 60-bar throughput band (#96) |
 | [`c353274`](https://github.com/Pappet/harux/commit/c35327476243aecfd9c5763052ef890b6216fd38) | `feat(ui):` detail panel restructure — header / tabs / validation / fields (#98) |
+| [`eeb4fd2`](https://github.com/Pappet/harux/commit/eeb4fd208c2e8f15b462a65b66c2fef21d5cc7f8) | `feat(ui):` empty-state CLI hint + Phase 6 polish pass (#101) |
 | [`1993bcb`](https://github.com/Pappet/harux/commit/1993bcb07709460bce5d468c046be6e2f1db533c) | `feat(a11y):` keyboard navigation for message list rows |
 | [`f5c650a`](https://github.com/Pappet/harux/commit/f5c650aa025132a5a6e660092957fd3ad69099ec) | `feat(ui):` typography + color foundation for v0.5.0 redesign (#86) |
 

--- a/static/app.js
+++ b/static/app.js
@@ -12,7 +12,26 @@ const ICONS = {
     copy: '<svg class="i-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>',
     chevronRight: '<svg class="i-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>',
     chevronDown: '<svg class="i-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>',
+    xMark: '<svg class="i-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>',
 };
+
+// Empty-state markup for the detail panel when no message is selected.
+const DETAIL_EMPTY_HTML = `
+<div class="empty-state">
+    <div class="empty-card">
+        <div class="glyph">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                <polyline points="14 2 14 8 20 8"/>
+                <line x1="16" y1="13" x2="8" y2="13"/>
+                <line x1="16" y1="17" x2="8" y2="17"/>
+                <polyline points="10 9 9 9 8 9"/>
+            </svg>
+        </div>
+        <h3>No message selected</h3>
+        <p>Pick a message from the list to inspect its segments, raw payload, ACK, or JSON.</p>
+    </div>
+</div>`;
 
 // --- State ---
 let messages = [];
@@ -272,7 +291,7 @@ function connectWs() {
             renderHealthPills();
             renderThroughputBand();
             resetDetailHeader();
-            document.getElementById('detail-content').innerHTML = '<div class="empty-state"><p>No message selected</p></div>';
+            document.getElementById('detail-content').innerHTML = DETAIL_EMPTY_HTML;
         }
     };
 }
@@ -389,11 +408,13 @@ async function pollStats() {
             }
         }
 
-        // listening pill port + empty-state hint
+        // listening pill port + empty-state hint + CLI snippet port
         if (stats.mllp_port) {
             document.getElementById('pill-port').textContent = stats.mllp_port;
             const emptyPort = document.getElementById('mllp-port');
             if (emptyPort) emptyPort.textContent = stats.mllp_port;
+            const cliPort = document.getElementById('cli-port');
+            if (cliPort) cliPort.textContent = stats.mllp_port;
         }
     } catch (e) { }
 }
@@ -861,7 +882,7 @@ function renderDetail() {
     const pinLabel = isPinned ? 'Pinned' : 'Pin diff';
 
     const tagChipsHtml = (msg.tags || []).map(t =>
-        `<span class="msg-tag">${esc(t)} <span class="msg-tag-remove" onclick="removeTag('${msg.id}', '${escAttr(escJS(t))}')">×</span></span>`
+        `<span class="msg-tag">${esc(t)}<span class="msg-tag-remove" onclick="removeTag('${msg.id}', '${escAttr(escJS(t))}')" title="Remove tag" aria-label="Remove tag">${ICONS.xMark}</span></span>`
     ).join('');
     const tagAddHtml = `
         <div class="msg-tag-add">
@@ -1020,6 +1041,7 @@ function renderTab() {
                 <summary>
                     <span class="summary-icon">${ICONS.warning}</span>
                     <span class="summary-text"><strong>${headline}</strong> · ${summaryLine}</span>
+                    <span class="summary-chevron">${ICONS.chevronRight}</span>
                 </summary>
                 <ul class="validation-warnings-list">
                     ${warnings.map(w => {
@@ -1295,7 +1317,7 @@ async function clearMessages() {
         renderHealthPills();
         renderThroughputBand();
         resetDetailHeader();
-        document.getElementById('detail-content').innerHTML = '<div class="empty-state"><p>No message selected</p></div>';
+        document.getElementById('detail-content').innerHTML = DETAIL_EMPTY_HTML;
     } catch (e) {
         console.error('Failed to clear messages:', e);
     }
@@ -1433,6 +1455,13 @@ function copySegment(segIdx, el) {
 function copyRawMessage(el) {
     if (!selectedMessage) return;
     copyToClipboard(selectedMessage.raw, el);
+}
+
+function copyCliSnippet(btn) {
+    const snippetEl = document.getElementById('cli-snippet');
+    if (!snippetEl) return;
+    const text = snippetEl.textContent.replace(/\s+/g, ' ').trim();
+    copyToClipboard(text, btn);
 }
 
 // --- Panel Splitter ---
@@ -1579,3 +1608,21 @@ renderHealthPills();
 renderSourceLegend();
 renderThroughputBand();
 pollStats();
+
+// Search shortcut: Cmd/Ctrl+K focuses the filter input. The hint chip
+// inside the input adapts to the platform (⌘K on Mac, ^K elsewhere).
+(function setupSearchShortcut() {
+    const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform || '');
+    const tip = document.getElementById('search-tip');
+    if (tip) tip.textContent = isMac ? '⌘K' : '^K';
+
+    document.addEventListener('keydown', (e) => {
+        if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'k') {
+            const input = document.getElementById('search-input');
+            if (!input) return;
+            e.preventDefault();
+            input.focus();
+            input.select();
+        }
+    });
+})();

--- a/static/index.html
+++ b/static/index.html
@@ -80,7 +80,9 @@
     <div class="main-container">
         <div class="list-panel">
             <div class="search-bar">
-                <input type="text" id="search-input" placeholder="Filter: message type, patient, facility, ID..." />
+                <svg class="i search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
+                <input type="text" id="search-input" placeholder="Filter: type, patient, facility, ID, has:errors…" />
+                <kbd class="search-tip" id="search-tip">⌘K</kbd>
             </div>
             <div class="source-rail" id="source-rail"></div>
             <div class="rate-band" id="rate-band">
@@ -106,11 +108,27 @@
             </div>
             <div class="message-list" id="message-list">
                 <div class="empty-state" id="empty-state">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
-                    </svg>
-                    <p>Waiting for HL7 messages...</p>
-                    <span class="hint">MLLP Server listening on port <span id="mllp-port">2575</span></span>
+                    <div class="empty-card">
+                        <div class="glyph">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
+                                <path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
+                            </svg>
+                        </div>
+                        <h3>Listening on :<span id="mllp-port">2575</span></h3>
+                        <p>No messages received yet.</p>
+                        <div class="cli-block" id="cli-block">
+                            <span class="prompt">$</span>
+                            <span class="cmd"><span id="cli-snippet">echo "MSH|^~\\&|TEST|FAC|RECV|ORG|20260101120000||ADT^A01|MSG001|P|2.5" \
+    | mllp-send localhost <span id="cli-port">2575</span></span></span>
+                            <button class="cmd-copy" onclick="copyCliSnippet(this)" title="Copy command" aria-label="Copy command">
+                                <svg class="i-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -137,11 +155,26 @@
                 <button class="detail-tab" data-tab="ack" onclick="switchTab('ack')">ACK</button>
                 <button class="detail-tab" data-tab="json" onclick="switchTab('json')">JSON</button>
                 <button class="detail-tab diff-tab" id="tab-btn-diff" data-tab="diff" onclick="switchTab('diff')"
-                    style="display:none">&#9651; Diff</button>
+                    style="display:none">
+                    <svg class="i-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+                    Diff vs pinned
+                </button>
             </div>
             <div class="detail-content" id="detail-content">
                 <div class="empty-state">
-                    <p>Click a message to view details</p>
+                    <div class="empty-card">
+                        <div class="glyph">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                                <polyline points="14 2 14 8 20 8"/>
+                                <line x1="16" y1="13" x2="8" y2="13"/>
+                                <line x1="16" y1="17" x2="8" y2="17"/>
+                                <polyline points="10 9 9 9 8 9"/>
+                            </svg>
+                        </div>
+                        <h3>No message selected</h3>
+                        <p>Pick a message from the list to inspect its segments, raw payload, ACK, or JSON.</p>
+                    </div>
                 </div>
             </div>
         </div>

--- a/static/style.css
+++ b/static/style.css
@@ -266,29 +266,63 @@ body.resizing * {
 }
 
 .search-bar {
-    padding: 10px 16px;
+    position: relative;
+    padding: 10px 14px;
     border-bottom: 1px solid var(--border);
     background: var(--bg-secondary);
 }
 
+.search-bar .search-icon {
+    position: absolute;
+    left: 24px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-muted);
+    pointer-events: none;
+}
+
 .search-bar input {
     width: 100%;
-    padding: 8px 12px;
+    padding: 8px 50px 8px 36px;
     background: var(--bg-primary);
     border: 1px solid var(--border);
     border-radius: 6px;
     color: var(--text-primary);
-    font-size: 13px;
+    font-size: 12.5px;
     font-family: var(--font-mono);
     outline: none;
+    transition: border-color 0.12s, background 0.12s;
 }
 
 .search-bar input:focus {
     border-color: var(--accent);
+    background: var(--bg-primary);
 }
 
 .search-bar input::placeholder {
     color: var(--text-muted);
+    opacity: 0.7;
+}
+
+.search-bar .search-tip {
+    position: absolute;
+    right: 22px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    background: var(--bg-tertiary);
+    color: var(--text-muted);
+    padding: 1px 5px;
+    border-radius: 3px;
+    pointer-events: none;
+    transition: opacity 0.12s;
+    border: 1px solid var(--border);
+}
+
+.search-bar input:focus ~ .search-tip,
+.search-bar input:not(:placeholder-shown) ~ .search-tip {
+    opacity: 0;
 }
 
 .message-list {
@@ -504,6 +538,7 @@ body.resizing * {
     flex: 1;
     height: 1px;
     background: var(--border);
+    opacity: 0.6;
 }
 
 .group-header .count {
@@ -521,23 +556,105 @@ body.resizing * {
     align-items: center;
     justify-content: center;
     height: 100%;
-    color: var(--text-muted);
-    gap: 12px;
+    padding: 32px;
 }
 
-.empty-state svg {
-    width: 48px;
-    height: 48px;
-    opacity: 0.3;
+.empty-card {
+    max-width: 460px;
+    width: 100%;
+    text-align: center;
 }
 
-.empty-state p {
-    font-size: 14px;
+.empty-card .glyph {
+    width: 56px;
+    height: 56px;
+    display: grid;
+    place-items: center;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    margin: 0 auto 14px;
+    color: var(--accent);
+    opacity: 0.85;
 }
 
-.empty-state .hint {
-    font-size: 12px;
+.empty-card .glyph svg {
+    width: 24px;
+    height: 24px;
+}
+
+.empty-card h3 {
+    color: var(--text-primary);
+    font-size: 15px;
+    margin-bottom: 6px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+}
+
+.empty-card h3 #mllp-port {
+    color: var(--accent);
     font-family: var(--font-mono);
+}
+
+.empty-card p {
+    color: var(--text-muted);
+    font-size: 12px;
+    margin-bottom: 16px;
+    line-height: 1.5;
+}
+
+.cli-block {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 38px 12px 14px;
+    text-align: left;
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    position: relative;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.cli-block .prompt {
+    color: var(--text-muted);
+    user-select: none;
+    margin-right: 6px;
+}
+
+.cli-block .cmd {
+    color: var(--text-secondary);
+}
+
+.cli-block .cmd-copy {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 24px;
+    height: 24px;
+    display: grid;
+    place-items: center;
+    color: var(--text-muted);
+    background: transparent;
+    border: 1px solid transparent;
+    cursor: pointer;
+    border-radius: 4px;
+    padding: 0;
+    transition: color 0.12s, background 0.12s, border-color 0.12s;
+}
+
+.cli-block .cmd-copy:hover {
+    color: var(--accent);
+    background: var(--bg-tertiary);
+    border-color: var(--border);
+}
+
+.cli-block .cmd-copy.copy-success {
+    color: var(--success);
+    background: rgba(79, 185, 138, 0.10);
+    border-color: rgba(79, 185, 138, 0.35);
 }
 
 /* Source color indicator */
@@ -632,8 +749,17 @@ body.resizing * {
 }
 
 .source-chip .num {
-    color: var(--text-muted);
+    color: var(--text-secondary);
     font-size: 10px;
+    background: rgba(255, 255, 255, 0.04);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-variant-numeric: tabular-nums;
+}
+
+.source-chip.active .num {
+    color: var(--accent);
+    background: rgba(122, 162, 255, 0.12);
 }
 
 /* Overflow menu (Color by Port toggle) */
@@ -1031,6 +1157,7 @@ body.resizing * {
     gap: 6px;
     padding: 11px 14px;
     font-size: 12px;
+    font-weight: 500;
     color: var(--text-secondary);
     cursor: pointer;
     border-bottom: 2px solid transparent;
@@ -1040,6 +1167,10 @@ body.resizing * {
     border-left: none;
     border-right: none;
     margin-bottom: -1px;
+}
+
+.detail-tab.active {
+    font-weight: 600;
 }
 
 .detail-tab:hover {
@@ -1191,12 +1322,18 @@ body.resizing * {
 }
 
 .field-table tr.warn .field-val::after {
-    content: ' ⚠ required';
-    margin-left: 8px;
+    content: 'required';
+    margin-left: 10px;
     color: var(--warning);
     font-family: var(--font-sans);
     font-size: 10px;
     font-style: italic;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    background: rgba(229, 165, 75, 0.10);
+    padding: 1px 6px;
+    border-radius: 3px;
+    vertical-align: middle;
 }
 
 /* Raw view */
@@ -1291,32 +1428,39 @@ body.resizing * {
 }
 
 .msg-tag {
-    background: rgba(122, 162, 255, 0.1);
-    border: 1px solid var(--accent-dim);
+    background: rgba(122, 162, 255, 0.10);
+    border: 1px solid rgba(122, 162, 255, 0.30);
     color: var(--accent);
     font-size: 11px;
-    padding: 2px 6px;
-    border-radius: 4px;
-    display: flex;
+    padding: 2px 4px 2px 8px;
+    border-radius: 999px;
+    display: inline-flex;
     align-items: center;
     gap: 4px;
+    font-family: var(--font-mono);
+    line-height: 1;
 }
 
 .msg-tag-remove {
+    display: inline-grid;
+    place-items: center;
+    width: 16px;
+    height: 16px;
     cursor: pointer;
-    font-weight: bold;
+    color: var(--accent);
     opacity: 0.7;
-    transition: opacity 0.15s;
-    padding: 0 2px;
+    border-radius: 50%;
+    transition: opacity 0.12s, background 0.12s, color 0.12s;
 }
 
 .msg-tag-remove:hover {
     opacity: 1;
     color: var(--error);
+    background: rgba(234, 99, 99, 0.12);
 }
 
 .msg-tag-add {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 4px;
 }
@@ -1438,15 +1582,14 @@ body.resizing * {
     display: none;
 }
 
-.validation-summary > summary::after {
-    content: '▸';
+.validation-summary .summary-chevron {
     margin-left: auto;
     color: var(--text-muted);
-    font-size: 11px;
     transition: transform 0.15s;
+    flex-shrink: 0;
 }
 
-.validation-summary[open] > summary::after {
+.validation-summary[open] .summary-chevron {
     transform: rotate(90deg);
 }
 


### PR DESCRIPTION
## Summary

Final phase of the v0.5.0 UI redesign. Implements item **12** of `CLAUDE_CODE_HANDOFF.md` plus a polish pass that rounds off the visual system. With this PR merged, the v0.5.0 redesign is complete.

### Item 12 — Empty state with CLI hint

The lightning-bolt empty state is replaced with a real onboarding card:

- New `.empty-card` centered in the message list pane.
- Soft tray glyph + `Listening on :PORT` headline (port comes from `stats.mllp_port`).
- "No messages received yet." description.
- `.cli-block` with the sample command and a copy button. The port inside the snippet is wired to `#cli-port` so it stays in sync with the actual listener.

The detail panel's cold "Click a message to view details" placeholder becomes a matching `.empty-card` with a small document icon and a one-line hint. Both the static initial markup and the runtime fallback (cleared event, `clearMessages`) reuse a `DETAIL_EMPTY_HTML` constant so the panel always renders the same card.

### Polish pass

| Item | What |
|---|---|
| **Search ⌘K** | `Cmd+K` / `Ctrl+K` focuses the filter input. Hint chip inside the input reads `⌘K` on Mac and `^K` elsewhere, fades out on focus or when typing. |
| **Search bar** | Leading magnifier SVG icon; placeholder text mentions `has:errors`. |
| **Tag-chip remove** | `×` text glyph swapped for the shared lucide-style x SVG. `.msg-tag` becomes a pill with hover halo around the remove control. |
| **Validation chevron** | Trailing `▸` text glyph replaced with the chevron SVG; rotates 90° on `[open]`. |
| **`tr.warn` "required"** | Dropped the `⚠` glyph; suffix is now a small uppercase `required` chip in `--warning` on a tinted amber background. |
| **Diff tab** | Right-aligned tab gains the chevron SVG and reads `Diff vs pinned`. |
| **Source-chip num** | Count badges get a tinted background; active variant uses the accent tint. |
| **Group header** | `::after` divider drops to 60% opacity for a calmer rhythm. |
| **Tab font weight** | `.detail-tab.active` renders at `font-weight: 600` for clearer reading rhythm. |
| **`xMark` icon** | New entry in the `ICONS` map. |

## Out of scope

Anything beyond redesign brief items 1–14. The brief is now fully implemented across phases 1–6.

## Test plan

- [ ] CI: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test`
- [ ] Manual: launch with no traffic — empty card shows correct port, CLI block reads cleanly, copy button copies the full command.
- [ ] Manual: send a message — empty card disappears; send another, list shows two-line rows.
- [ ] Manual: clear via /api/clear — empty card returns; detail panel shows "No message selected" card.
- [ ] Manual: press `Cmd+K` (Mac) or `Ctrl+K` (Linux/Windows) anywhere — filter input gains focus, contents are selected. Hint chip fades.
- [ ] Manual: select a message — Diff tab right-aligned with chevron, reads `Diff vs pinned`. Active tab text reads bolder.
- [ ] Manual: open a tagged message — pill-shaped tag with x icon; click x removes the tag.
- [ ] Manual: open a message with `MISSING_FIELD` warnings — `required` chip appears next to the empty value cell, no `⚠` glyph.
- [ ] Manual: click the validation summary — chevron rotates, full warning list expands; click again to collapse.

Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)