### PR TITLE
perf(ui): memoize parsed search query + short-circuit field checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **Pin click leaked to row selection** — clicking the diff-pin icon previously also selected the underlying message row. `toggleDiffPin` now calls `event.stopPropagation()` when invoked from the row.
 
 ### Changed
-- **Performance** — eliminated multiple redundant `Vec` allocations in the HL7 parsing engine (`parse_segment` and `parse_message`), substantially reducing heap allocations per message and improving throughput.
+- **Performance — HL7 parser allocations** — eliminated multiple redundant `Vec` allocations in the HL7 parsing engine (`parse_segment` and `parse_message`), substantially reducing heap allocations per message and improving throughput (#102)
+- **Performance — frontend search filter** — `matchesSearch` now uses a pre-parsed query (`getParsedQuery`) so the `has:warnings` / `has:errors` prefix stripping and lowercasing happen once per query instead of once per message. Per-message field checks short-circuit on the first hit and skip the lowercasing when the field is empty. Bounded `parsedQueryCache` (max 100 entries) prevents memory growth from many unique searches (#100)
 - **Typography** — adopted Inter (sans) and JetBrains Mono (mono) via Google Fonts; first phase of the v0.5.0 UI redesign (#86)
 - **Color palette** — refreshed dark theme: deeper backgrounds (`--bg-primary` `#0b0d12`, `--bg-secondary` `#131620`, `--bg-tertiary` `#1b1f2c`), cooler accent (`--accent` `#7aa2ff`), tuned success/error tones (`--success` `#4fb98a`, `--error` `#ea6363`) for higher contrast against the deeper canvas (#86)
 - **Top-bar health pills** — replaced the dot-and-counter `.stats-bar` with a row of pill-shaped status indicators: `listening :PORT` (green pulsing dot when WebSocket connected, red static when disconnected), `conns N / MAX`, `rate N/min` with a 60-second sparkline, `last Ns ago` (refreshed once per second), `errors N` (red value when nonzero). The previously hidden "rejected" stat is preserved as a hidden pill that surfaces only when `rejected_connections > 0`. The `total messages` counter was removed from the header; the rolling rate pill replaces it as the live-traffic signal (#92)
@@ -80,6 +81,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 | Commit | Description |
 |--------|-------------|
 | [`e2d1501`](https://github.com/Pappet/harux/commit/e2d15015cabb8fe3b3c4fa7d8f9e68eda84677ff) | `perf(parser):` eliminate redundant Vec allocations in HL7 parsing |
+| [`c118c5e`](https://github.com/Pappet/harux/commit/c118c5e9cd4646d0c56067112c9e5be9513f39a9) | `perf(ui):` memoize parsed search query + short-circuit field checks (#100) |
 | [`a14f0de`](https://github.com/Pappet/harux/commit/a14f0de20053257e6b9cd2b9e6063fc8e2daf8dc) | `fix:` resolve ISO-8859-1 charset encoding issues (#78) |
 | [`a6f1ce7`](https://github.com/Pappet/harux/commit/a6f1ce7e1e8deb5dbead3248e099423231b1cd09) | `feat(a11y):` ARIA labels, native buttons, global focus ring |
 | [`4554d90`](https://github.com/Pappet/harux/commit/4554d90488df2bd604f1017d024013cd08331f72) | `feat(ui):` top-bar health pills replace stats dots (#92) |

--- a/static/app.js
+++ b/static/app.js
@@ -699,11 +699,40 @@ function buildMessageRow(msg) {
     return row;
 }
 
+// Memoize parsed search queries so the `has:warnings` / `has:errors` prefix
+// stripping and the lowercasing of the residual query happen once per query
+// instead of once per message during each filter pass. Bounded at 100 entries
+// so an attacker (or a developer typing fast) cannot grow the cache without
+// limit.
+const parsedQueryCache = new Map();
+const PARSED_QUERY_CACHE_MAX = 100;
+
+function getParsedQuery(query) {
+    const cached = parsedQueryCache.get(query);
+    if (cached) return cached;
+
+    let q = query.toLowerCase().trim();
+    let hasWarnings = false;
+    let hasErrors = false;
+    if (q.startsWith('has:warnings')) {
+        hasWarnings = true;
+        q = q.slice('has:warnings'.length).trim();
+    } else if (q.startsWith('has:errors')) {
+        hasErrors = true;
+        q = q.slice('has:errors'.length).trim();
+    }
+
+    const result = { q, hasWarnings, hasErrors };
+    if (parsedQueryCache.size >= PARSED_QUERY_CACHE_MAX) parsedQueryCache.clear();
+    parsedQueryCache.set(query, result);
+    return result;
+}
+
 function renderMessageList() {
     const list = document.getElementById('message-list');
     const empty = document.getElementById('empty-state');
     let filtered = searchQuery
-        ? messages.filter(m => matchesSearch(m, searchQuery))
+        ? messages.filter(m => matchesSearch(m, getParsedQuery(searchQuery)))
         : messages;
     if (showBookmarkedOnly) {
         filtered = filtered.filter(m => m.bookmarked);
@@ -746,26 +775,29 @@ function renderMessageList() {
     }
 }
 
-function matchesSearch(msg, query) {
-    let q = query.toLowerCase().trim();
-    if (q.startsWith('has:warnings')) {
+// Filter check using a pre-parsed query (see getParsedQuery). Each `if` is a
+// short-circuit early return so no further `.toLowerCase()` runs once a field
+// matches. Empty-string fields are skipped before the lowercasing — saves a
+// no-op call per absent property.
+function matchesSearch(msg, parsedQuery) {
+    if (parsedQuery.hasWarnings) {
         if ((msg.validation_warning_count || 0) === 0 && !msg.has_segment_errors) return false;
-        q = q.replace('has:warnings', '').trim();
-        if (!q) return true;
-    } else if (q.startsWith('has:errors')) {
+    } else if (parsedQuery.hasErrors) {
         if (!msg.has_segment_errors) return false;
-        q = q.replace('has:errors', '').trim();
-        if (!q) return true;
     }
-    return (
-        (msg.message_type || '').toLowerCase().includes(q) ||
-        (msg.sending_facility || '').toLowerCase().includes(q) ||
-        (msg.patient_name || '').toLowerCase().includes(q) ||
-        (msg.patient_id || '').toLowerCase().includes(q) ||
-        (msg.message_control_id || '').toLowerCase().includes(q) ||
-        (msg.source_addr || '').toLowerCase().includes(q) ||
-        (msg.tags || []).some(t => t.toLowerCase().includes(q))
-    );
+
+    const q = parsedQuery.q;
+    if (!q) return true;
+
+    if (msg.patient_name && msg.patient_name.toLowerCase().includes(q)) return true;
+    if (msg.message_type && msg.message_type.toLowerCase().includes(q)) return true;
+    if (msg.sending_facility && msg.sending_facility.toLowerCase().includes(q)) return true;
+    if (msg.patient_id && msg.patient_id.toLowerCase().includes(q)) return true;
+    if (msg.message_control_id && msg.message_control_id.toLowerCase().includes(q)) return true;
+    if (msg.source_addr && msg.source_addr.toLowerCase().includes(q)) return true;
+    if (msg.tags && msg.tags.some(t => t.toLowerCase().includes(q))) return true;
+
+    return false;
 }
 
 async function selectMessage(id) {


### PR DESCRIPTION
## Summary

Cherry-picked from #100 (Bolt's frontend search optimization) and rebased onto current `main` so it preserves Phase 3's `renderMessageList` rewrite (group headers, `buildMessageRow`, sticky time buckets).

The original PR's branch was based on `818a59d` — pre-redesign main — so applying it as-is would have wholesale-replaced `renderMessageList` and undone the Phase 3 grouping shipped in #95. This PR carries only the substance of Bolt's optimization on top of the current code.

## Changes

`static/app.js`:

- New `parsedQueryCache` (Map, bounded at 100 entries via `PARSED_QUERY_CACHE_MAX`) and `getParsedQuery(query)` helper.
- Lowercasing, trimming, and `has:warnings` / `has:errors` prefix stripping happen **once per query** instead of once per message per filter pass.
- Cache clears wholesale once size hits the cap — simple, no LRU bookkeeping.
- `matchesSearch(msg, parsedQuery)` rewritten as a sequential short-circuit cascade: each property is checked behind a truthiness gate so `.toLowerCase()` is skipped when the field is empty or null.
- `renderMessageList`'s call site passes the cached parsed query instead of the raw search string.

## Behavior preserved

- Same fields searched (`patient_name`, `message_type`, `sending_facility`, `patient_id`, `message_control_id`, `source_addr`, `tags`).
- `has:warnings` and `has:errors` operators behave identically — empty residual query after stripping the operator still returns `true` when the message qualifies.
- All Phase 3 group headers, sticky buckets, source rail dimming, source coloring, validation filter, and bookmark filter continue to work.

## Why not just merge #100

- Source branch base is `818a59d`. Direct merge would conflict on `renderMessageList` and the auto-resolution kept the bot's stale rewrite, dropping Phase 3 work. I aborted the rebase and re-applied only the relevant additions on a fresh branch off current main.
- Bolt's PR description quotes "203 ms → 92 ms" on a 1000-row filter — plausible, unverified locally. Memoizing a per-query lowercase + strip is a real win once the message buffer is large.

## Test plan

- [ ] CI: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test`
- [ ] Manual: type rapidly into the filter input — list filters as expected, no console errors.
- [ ] Manual: type `has:warnings`, `has:errors`, `has:warnings adt`, `has:errors john` — same matches as before #100.
- [ ] Manual: search by patient name, MRN, message type, source address, tag — all hit.
- [ ] Manual: clear search — full list returns; messages still grouped by time bucket; source highlight behavior unchanged.
- [ ] Manual: type 100+ unique queries — cache resets cleanly, no JS errors.

Closes #100. Bolt's commit `cc50dcc` is superseded by this rebased version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)