### PR TITLE
chore(release): v0.5.0 — UI Redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 ## [Unreleased]
 
+---
+
+## [0.5.0] – 2026-05-08 – UI Redesign
+
+> Visual + IA refactor of the entire frontend (`CLAUDE_CODE_HANDOFF.md`, items 1–14, plus the chrome-cleanup follow-up). Six numbered phases shipped between #87 and #103 plus a chrome-cleanup pass in #105. Two perf wins (#102 parser allocations, #100 frontend search filter) round out the release. No protocol, API, or storage changes.
+
 ### Added
 - **Keyboard accessibility for message rows** — message list rows now support `Tab` focus navigation and `Enter`/`Space` to select; a 2px accent outline appears on `:focus-visible`. Improves screen-reader and keyboard-only workflows.
 - **ARIA labels on message rows + bookmark/pin controls** — each row exposes a synthesized `aria-label` (facility, type, time); the bookmark and pin controls were promoted from `<span>` to native `<button>` so they receive `Tab` focus, keyboard activation, and `aria-label`. Pin clicks now `stopPropagation` so the row beneath does not also select.
@@ -46,6 +52,29 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **Diff tab affordance** — the right-aligned Diff tab gains a chevron icon and reads `Diff vs pinned` so it visually announces "leads to the comparison view" (#101)
 - **Source-chip count badge + tab font weight** — source-chip count badges get a tinted background so they pop against the chip body; active tabs render at `font-weight: 600` for a clearer reading rhythm (#101)
 
+### Commit History (chronological)
+
+#### 2026-05-08
+
+| Commit | Description |
+|--------|-------------|
+| `release/v0.5.0` (this commit) | `chore(release):` v0.5.0 — UI Redesign |
+| [`f99e426`](https://github.com/Pappet/harux/commit/f99e426) | `feat(ui):` chrome cleanup — topbar pills + inbox controls row (#105) |
+| [`3c64799`](https://github.com/Pappet/harux/commit/3c64799) | `perf(ui):` memoize parsed search query + short-circuit field checks (#104) |
+| [`6040b4c`](https://github.com/Pappet/harux/commit/6040b4c) | `perf(parser):` eliminate redundant Vec allocations in HL7 parsing (#102) |
+| [`9fa7368`](https://github.com/Pappet/harux/commit/9fa7368) | `feat(ui):` empty-state CLI hint + Phase 6 polish pass (#103) |
+| [`549919e`](https://github.com/Pappet/harux/commit/549919e) | `feat(ui):` detail panel restructure — header / tabs / validation / fields (#99) |
+| [`1ea2e2b`](https://github.com/Pappet/harux/commit/1ea2e2b) | `feat(ui):` always-visible source rail + 60-bar throughput band (#97) |
+| [`bdf92b0`](https://github.com/Pappet/harux/commit/bdf92b0) | `feat(ui):` two-line message rows with time grouping + ACK chips (#95) |
+| [`4426a61`](https://github.com/Pappet/harux/commit/4426a61) | `feat(ui):` top-bar health pills replace stats dots (#93) |
+| [`90c7520`](https://github.com/Pappet/harux/commit/90c7520) | `feat(a11y):` ARIA labels, native buttons, global focus ring (#91) |
+| [`c4089ad`](https://github.com/Pappet/harux/commit/c4089ad) | `feat(ui):` typography + color foundation for v0.5.0 redesign (#87) |
+| [`2569bd3`](https://github.com/Pappet/harux/commit/2569bd3) | `feat(a11y):` keyboard navigation for message list rows (#88) |
+| [`dfdda56`](https://github.com/Pappet/harux/commit/dfdda56) | `🛡️ Sentinel:` [HIGH] Fix Cross-Site Scripting (XSS) vulnerability (#85) |
+| [`e6fa07c`](https://github.com/Pappet/harux/commit/e6fa07c) | `fix:` resolve XSS vulnerability in HTML attribute injection (#84) |
+| [`1ac0b4e`](https://github.com/Pappet/harux/commit/1ac0b4e) | `⚡ Bolt:` optimize dictionary lookup to O(1) where possible (#83) |
+| [`47d1fa7`](https://github.com/Pappet/harux/commit/47d1fa7) | `fix:` resolve ISO-8859-1 charset encoding issues (#82) |
+
 ---
 
 ## [0.4.0] – 2026-03-08 – Message Analysis
@@ -76,23 +105,6 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **Typical-segment badge colour for data type warnings** — `INVALID_DATATYPE` warnings no longer turn a segment badge yellow; only `MISSING_FIELD` triggers amber, keeping the badge colour semantics accurate (red = missing segment, amber = missing required field, blue = present)
 
 ### Commit History (chronological)
-
-#### 2026-05-08
-
-| Commit | Description |
-|--------|-------------|
-| [`e2d1501`](https://github.com/Pappet/harux/commit/e2d15015cabb8fe3b3c4fa7d8f9e68eda84677ff) | `perf(parser):` eliminate redundant Vec allocations in HL7 parsing |
-| [`c118c5e`](https://github.com/Pappet/harux/commit/c118c5e9cd4646d0c56067112c9e5be9513f39a9) | `perf(ui):` memoize parsed search query + short-circuit field checks (#100) |
-| [`b16cc5c`](https://github.com/Pappet/harux/commit/b16cc5c6f80ec3b93162137cb2688fbfa50a5b5c) | `feat(ui):` chrome cleanup — topbar pills + inbox controls row |
-| [`a14f0de`](https://github.com/Pappet/harux/commit/a14f0de20053257e6b9cd2b9e6063fc8e2daf8dc) | `fix:` resolve ISO-8859-1 charset encoding issues (#78) |
-| [`a6f1ce7`](https://github.com/Pappet/harux/commit/a6f1ce7e1e8deb5dbead3248e099423231b1cd09) | `feat(a11y):` ARIA labels, native buttons, global focus ring |
-| [`4554d90`](https://github.com/Pappet/harux/commit/4554d90488df2bd604f1017d024013cd08331f72) | `feat(ui):` top-bar health pills replace stats dots (#92) |
-| [`e658905`](https://github.com/Pappet/harux/commit/e658905e9faf919031eb267d8179c720d857e468) | `feat(ui):` two-line message rows with time grouping + ACK chips (#94) |
-| [`3e49222`](https://github.com/Pappet/harux/commit/3e49222e15524144e94b7c780cf1cb03e2a0b21a) | `feat(ui):` always-visible source rail + 60-bar throughput band (#96) |
-| [`c353274`](https://github.com/Pappet/harux/commit/c35327476243aecfd9c5763052ef890b6216fd38) | `feat(ui):` detail panel restructure — header / tabs / validation / fields (#98) |
-| [`eeb4fd2`](https://github.com/Pappet/harux/commit/eeb4fd208c2e8f15b462a65b66c2fef21d5cc7f8) | `feat(ui):` empty-state CLI hint + Phase 6 polish pass (#101) |
-| [`1993bcb`](https://github.com/Pappet/harux/commit/1993bcb07709460bce5d468c046be6e2f1db533c) | `feat(a11y):` keyboard navigation for message list rows |
-| [`f5c650a`](https://github.com/Pappet/harux/commit/f5c650aa025132a5a6e660092957fd3ad69099ec) | `feat(ui):` typography + color foundation for v0.5.0 redesign (#86) |
 
 #### 2026-03-08
 
@@ -330,7 +342,9 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 ---
 
-[Unreleased]: https://github.com/Pappet/harux/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Pappet/harux/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/Pappet/harux/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/Pappet/harux/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Pappet/harux/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Pappet/harux/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Pappet/harux/releases/tag/v0.1.0

--- a/CLAUDE_CODE_HANDOFF_CHROME_CLEANUP.md
+++ b/CLAUDE_CODE_HANDOFF_CHROME_CLEANUP.md
@@ -1,0 +1,235 @@
+# Harux Chrome Cleanup — Implementation Handoff for Claude Code
+
+**Reference mockup:** `harux-chrome-cleanup.html` (sibling file in this project).
+**Target files:** `static/index.html`, `static/style.css`, `static/app.js`.
+**Scope:** Visual + IA-only refactor. No protocol, API, or storage changes.
+
+---
+
+## Goals
+
+1. Eliminate the redundant throughput band above the message list — its counters move into the header pill row, the rate sparkline already lives in the `rate` pill.
+2. Relocate list-scoped controls (`Pause`, `Auto`, `Bookmarks`, validation cycle) out of the topbar and under the search bar, where they belong semantically.
+3. Distinguish **parser errors** (MLLP-level) from **validation errors** (segment-level) in the header — both stay visible, with clearer naming.
+4. Keep the existing 3-state validation filter button (`All → Warn → Error → All`) as-is. Only its position changes.
+
+---
+
+## 1. Topbar — promote pills, demote buttons
+
+### 1a. Pills row — split into two clusters with a divider
+
+Order, left to right:
+
+```
+[ listening :2575 ]  [ conns 0/100 ]  [ rate 12.4/min ▁▂▃▂▁ ]  [ last 9m ago ]
+                              │
+                              ▼ vertical divider
+[ total 360 ]  [ validation 12 ]  [ parse errors 18 ]
+```
+
+- Group A (existing): listener health — `listening`, `conns`, `rate`, `last`
+- 1px tall divider element (`.topbar-divider`, `width:1px; height:22px; background:var(--line); margin:0 4px`)
+- Group B (new from band): message counters — `total`, `validation`, `parse errors`
+
+**Naming**
+
+| Pill label | Source | Color rule |
+|---|---|---|
+| `total` | `messages.length` | always neutral |
+| `validation` | sum of `validation_warning_count` + `has_segment_errors` across all messages | amber when > 0 (`.health-pill.warn-pill`), neutral when 0 |
+| `parse errors` | `stats.parse_errors` | red when > 0 (`.health-pill.err-pill`), neutral when 0 |
+
+Important: the topbar's existing `errors` pill is renamed to **`parse errors`**. The new `validation` pill is the second one. They're not the same metric — keep both.
+
+CSS: re-use the existing `.health-pill`, `.warn-pill`, `.err-pill` classes from the M1–M3 redesign. Add `.topbar-divider`.
+
+### 1b. Topbar-right — keep only app-scoped actions
+
+Remove from `.topbar-right`:
+- `Pause`
+- `Auto`
+- `Bookmarks`
+- The 3-state validation filter button
+
+Keep in `.topbar-right`:
+- `Export`
+- `Clear` (danger style)
+
+(If a settings/gear button exists, keep it too.)
+
+---
+
+## 2. Throughput band — delete
+
+Remove the entire `.rate-band` block from `static/index.html`. Remove its CSS (`.rate-band`, `.rate-band .stat`, `.rate-band .spark-wrap`, `.rate-band svg.bars`) from `static/style.css`.
+
+The 60-second ring buffer and rate calculation stay — they still feed the `rate` pill's sparkline. Don't touch:
+- `rateBuckets` ring buffer
+- `rotateBuckets` interval
+- The polyline render in the `rate` pill
+
+Only the standalone bar histogram between source rail and message list goes away.
+
+---
+
+## 3. Inbox controls — new row under the search
+
+Insert a new row immediately below `.list-search`, above `.source-rail`:
+
+```html
+<div class="inbox-controls">
+  <button class="ctl-btn" id="btn-pause">⏸ Pause</button>
+  <button class="ctl-btn on ok-on" id="btn-autoscroll">↓ Auto</button>
+  <div class="ctl-divider"></div>
+  <button class="ctl-btn" id="btn-bookmarks">★ Bookmarks <span class="count">3</span></button>
+  <button class="ctl-btn" id="btn-validation">⚠ All</button>
+</div>
+```
+
+### CSS for the row
+
+```css
+.inbox-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line);
+}
+.ctl-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--fg-1);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all .12s;
+}
+.ctl-btn:hover { background: var(--bg-3); color: var(--fg-0); }
+.ctl-btn.on { background: var(--accent-bg); border-color: rgba(122,162,255,0.35); color: var(--accent); }
+.ctl-btn.on.warn-on { background: rgba(229,165,75,0.10); border-color: rgba(229,165,75,0.35); color: var(--warn); }
+.ctl-btn.on.err-on  { background: rgba(234,99,99,0.10); border-color: rgba(234,99,99,0.35); color: var(--err); }
+.ctl-btn.on.ok-on   { background: rgba(79,185,138,0.10); border-color: rgba(79,185,138,0.35); color: var(--ok); }
+.ctl-btn .count {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-2);
+  background: var(--bg-1);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+.ctl-divider { width: 1px; height: 18px; background: var(--line); margin: 0 4px; }
+```
+
+### Group separation
+
+The `.ctl-divider` between `Auto` and `Bookmarks` separates **stream controls** (Pause/Auto — affect live ingestion) from **filter controls** (Bookmarks/validation — affect what's displayed).
+
+---
+
+## 4. Validation filter button — keep the 3-state cycle
+
+**Do not rename.** **Do not change behavior.** It cycles `All → Warn → Error → All` exactly as before.
+
+Only change: it now sits in the new `.inbox-controls` row instead of the topbar, and uses the `.ctl-btn` class instead of the topbar's `.text-btn`.
+
+The `syncValidationFilterUI()` function in `app.js` keeps working — just update the toggle classes:
+
+```js
+function syncValidationFilterUI() {
+  const btn = document.getElementById('btn-validation');
+  if (!btn) return;
+  btn.classList.remove('on', 'warn-on', 'err-on');
+  if (validationFilter === 0) {
+    btn.innerHTML = '⚠ All';
+  } else if (validationFilter === 1) {
+    btn.innerHTML = '⚠ Warn';
+    btn.classList.add('on', 'warn-on');
+  } else if (validationFilter === 2) {
+    btn.innerHTML = '⚠ Error';
+    btn.classList.add('on', 'err-on');
+  }
+}
+```
+
+(Drop the inline `style.borderColor`/`style.color` writes — class-based styling is cleaner.)
+
+The same conversion applies to:
+- `togglePause()` — toggle `.on` (no color modifier)
+- `toggleAutoscroll()` — toggle `.on.ok-on`
+- `toggleBookmarkFilter()` — toggle `.on.warn-on` (gold star feel)
+
+---
+
+## 5. Source rail — minor tightening
+
+Single-source case: when `seenSources.size === 1`, hide the `Color by Port` toggle behind a `⋯` overflow at the rail's right edge. It's only useful with multiple senders.
+
+Implementation: render the toggle into a small popover triggered by an icon button (`.source-rail .more`). Existing `toggleColorByPort` handler unchanged — just relocate where it lives.
+
+---
+
+## 6. Wire-up summary (data flow unchanged)
+
+| New pill | Existing source | Update on |
+|---|---|---|
+| `total` | `messages.length` (or server `totalMessagesCount`) | every `addMessage` / `cleared` |
+| `validation` | `messages.reduce((n,m) => n + (m.validation_warning_count\|\|0) + (m.has_segment_errors?1:0), 0)` | every `flushAndRender` |
+| `parse errors` | `stats.parse_errors` | `pollStats` (existing) |
+
+If `validation` becomes a hot-loop bottleneck (very large inboxes), maintain a running counter that increments in `addMessage` and resets in `cleared`/`loadMessages`.
+
+---
+
+## 7. Concrete patch checklist
+
+- [ ] `static/index.html`
+  - [ ] Move `Pause`, `Auto`, `Bookmarks`, `btn-validation` buttons out of `.header-actions`
+  - [ ] Add new `<div class="inbox-controls">` row inside `.list-panel`, between `.search-bar` and `.source-legend`
+  - [ ] Re-insert those four buttons inside the new row, in order: Pause, Auto, divider, Bookmarks, btn-validation
+  - [ ] Inside `.stats-bar` (or its replacement `.health` row), append: divider element + 3 new pills (`total`, `validation`, `parse errors`)
+  - [ ] Rename the existing `errors` pill label to `parse errors`
+  - [ ] Delete `.rate-band` block entirely
+
+- [ ] `static/style.css`
+  - [ ] Add `.inbox-controls`, `.ctl-btn`, `.ctl-btn.on`, `.ctl-btn.on.warn-on`, `.ctl-btn.on.err-on`, `.ctl-btn.on.ok-on`, `.ctl-btn .count`, `.ctl-divider`
+  - [ ] Add `.topbar-divider`
+  - [ ] Remove `.rate-band` and its descendants
+  - [ ] Confirm `.health-pill.warn-pill` and `.health-pill.err-pill` exist (carry over from M1–M3 redesign if missing)
+
+- [ ] `static/app.js`
+  - [ ] Update `togglePause`, `toggleAutoscroll`, `toggleBookmarkFilter`, `syncValidationFilterUI` to use class toggles instead of inline styles
+  - [ ] Remove rate-band specific render code (the bar histogram between `<g id="bars">` tags)
+  - [ ] Keep the rate ring buffer and `rate` pill sparkline render
+  - [ ] Add `updateHeaderCounters()` called from `flushAndRender`, `pollStats`, `cleared` handler — writes `total`, `validation`, `parse errors` pill values
+
+---
+
+## 8. What NOT to touch
+
+- WebSocket protocol (`init`, `new_message`, `tags_updated`, `bookmark_toggled`, `lagged`, `cleared`)
+- API endpoints
+- Session persistence keys (`harux_session`, `_state`) and saved fields — `paused`, `autoscroll`, `showBookmarkedOnly`, `validationFilter` keep their meanings
+- Source color palette / `getSourceColor`
+- Diff-vs-pinned logic
+- Rate ring buffer — the data feeds the `rate` pill sparkline, just no longer the deleted band
+
+---
+
+## 9. Suggested commit order
+
+1. CSS additions (`.inbox-controls`, `.ctl-btn` family, `.topbar-divider`) — deployable without behavioral change
+2. Move buttons out of header into new `.inbox-controls` row + class refactor in `app.js`
+3. Add 3 new header pills + `updateHeaderCounters()`
+4. Rename `errors` → `parse errors`
+5. Delete `.rate-band` markup and CSS
+
+Each step lands on its own and the app stays usable between commits.

--- a/CLAUDE_CODE_HANDOFF_M4_M5.md
+++ b/CLAUDE_CODE_HANDOFF_M4_M5.md
@@ -1,0 +1,463 @@
+# Harux M4 + M5 — Implementation Handoff for Claude Code
+
+**Reference mockups:** `harux-m4-m5-suggestions.html` (this project, sibling file).
+**Scope:** Milestone 4 (Workflow & Testing) + Milestone 5 (Persistence).
+**Constraint:** Re-use the existing visual language from the M1–M3 redesign (`harux-redesigned.html`). Same CSS variables, same component primitives — health pills, segment cards, monospace meta rows, action buttons. Don't invent new chrome.
+
+---
+
+## Architecture changes that unlock everything
+
+These two infrastructure pieces are prerequisites. Land them first; everything else clicks into place.
+
+### A. `[targets]` table in `harux.toml`
+
+```toml
+[targets.orchestra-staging]
+host = "10.4.1.22"
+port = 6661
+tls = true
+default = true
+description = "Orchestra · staging"
+
+[targets.orchestra-prod]
+host = "orchestra.local"
+port = 6661
+tls = true
+description = "Orchestra · prod"
+```
+
+- New struct: `TargetConfig { host, port, tls, default, description, ca_cert? }`
+- Loader: `Vec<TargetConfig>` injected into AppState.
+- API: `GET /api/targets` → list with live health (last successful TCP connect timestamp + RTT).
+- Health-check task: every 30s, `tokio::spawn` per target, `TcpStream::connect_timeout(2s)`, store `(connected_at, rtt_ms, last_error)` in `Arc<RwLock<TargetHealth>>`.
+
+### B. MLLP client module (`src/mllp_client.rs`)
+
+Mirror of the existing `src/mllp.rs` but outbound. Exposes:
+
+```rust
+pub async fn send_to_target(
+    target: &TargetConfig,
+    raw: &[u8],
+    wait_for_ack: bool,
+    timeout: Duration,
+) -> Result<MllpSendResult, MllpClientError>;
+
+pub struct MllpSendResult {
+    pub sent_at: DateTime<Utc>,
+    pub ack_raw: Option<String>,
+    pub ack_code: Option<String>,    // AA / AE / AR
+    pub latency_ms: u32,
+    pub error: Option<String>,
+}
+```
+
+Used by replay, generator, and editor.
+
+---
+
+## M4 · Task 1 — Message replay (drawer)
+
+**Mockup:** Idea 1 in `harux-m4-m5-suggestions.html`.
+
+### UI
+
+New right-side drawer. Trigger: "Replay…" button in detail header (next to Bookmark / Pin diff).
+
+**DOM/CSS** — re-use mockup `.replay-drawer`, `.replay-source`, `.field-group`, `.preset-pills`, `.toggle-row`, `.switch`, `.result-banner`.
+
+**Drawer fields:**
+
+- **Source pill** (locked): `MSG_TYPE · patient · control_id`
+- **Target connection** (`<select>`): populated from `/api/targets`, default = `target.default == true`
+- **Modify before sending** (preset pills, multi-select):
+  - `As-is` (mutually exclusive with the rest)
+  - `Refresh MSH-7 (timestamp)` → server replaces with `now()`
+  - `New MSH-10 (control ID)` → server generates `MSG_<8 hex>`
+  - `Rewrite MRN…` → opens small inline form: old MRN → new MRN
+- **Toggles:** `wait_for_ack` (default on), `tag_replay_in_inbox` (default on)
+- **Footer:** Cancel / Send & open response / Replay (primary)
+
+### API
+
+```
+POST /api/messages/:id/replay
+{
+  "target_id": "orchestra-staging",
+  "modifiers": ["refresh_msh7", "new_msh10"],
+  "wait_for_ack": true,
+  "tag_replay_in_inbox": true
+}
+→ 200 {
+  "sent_at": "...",
+  "latency_ms": 42,
+  "ack_code": "AA",
+  "ack_raw": "MSH|...",
+  "tagged_message_id": "..."  // if also re-ingested
+}
+```
+
+### Wiring
+
+- Server reads stored raw bytes for `id`, applies modifiers (`replace_field("MSH", 7, ts)`).
+- Calls `mllp_client::send_to_target`.
+- If `tag_replay_in_inbox`, the response message (or echoed source) lands in the inbox with auto-tags `replay`, `from:<source_id>`. Detail header shows a `↻ replay of MSG042185` link.
+- Keyboard shortcut: `R` on a focused row → replay-to-default-target without opening the drawer (toast: "Replayed to staging · AA · 42ms").
+
+---
+
+## M4 · Task 2 — Template generator
+
+**Mockup:** Idea 2.
+
+### Templates
+
+Ship as `.hl7` files in `examples/templates/`:
+
+```
+examples/templates/
+  adt/
+    A01-admit.hl7
+    A03-discharge.hl7
+    A08-update.hl7
+  orders/
+    ORM-O01.hl7
+    OMG-O19.hl7
+  results/
+    ORU-R01.hl7
+```
+
+Each file may include front-matter for dynamic field tags:
+
+```
+# harux:dynamic MSH-7=now MSH-10=uuid PID-3.1=faker.mrn
+MSH|^~\&|HARUX_TEST|HARUX.LAB|...
+```
+
+### UI
+
+Two-column layout — sidebar of templates, main = form view of segments.
+
+**Sidebar:** group by category (ADT / Orders / Results / Custom). Active template gets accent left-border. "+ New from received…" lifts any inbox message into a saved template.
+
+**Main:**
+
+- Tab strip: `Form` / `Raw HL7` / `Preview`
+- **Form tab:** segment cards (`.gen-segment-card`), each field as `key | inline-input` row. Dynamic fields show `~ now`, `~ uuid` purple tag and disable manual input by default.
+- **Toolbar right:** `Sample faker data` (re-rolls all faker fields), `Save as preset`.
+- **Footer:** target chip, `Send 1`, `Send <N>` with editable count, `Send & watch` (primary — sends + jumps to inbox filtered to received responses).
+
+### API
+
+```
+GET  /api/templates               → list templates
+GET  /api/templates/:id           → full template (raw + dynamic spec)
+POST /api/templates               → save new (from form / from existing message)
+POST /api/templates/:id/send      → render dynamics, send N copies
+{
+  "target_id": "...",
+  "field_overrides": { "PID-5": "Romero^Marcus^J" },
+  "count": 50,
+  "interval_ms": 100      // for burst pacing
+}
+→ stream of SSE events { sent, ack_code, latency_ms } per message
+```
+
+### Burst send
+
+Use SSE so the UI shows live progress. Show transient progress panel:
+
+```
+▓▓▓▓▓▓▓▓░░░░░░░░  24 / 50 sent · 22 AA · 2 AE · avg 38ms
+```
+
+---
+
+## M4 · Task 3 — Raw HL7 editor
+
+**Mockup:** Idea 3.
+
+### UI
+
+Full-screen overlay (escape to close). Triggered from "Edit raw…" on any inbox message, or from the generator's "Raw HL7" tab.
+
+Three-column body:
+
+1. **Gutter** (line numbers, warning markers)
+2. **Code area** — `<textarea>` styled to look like the mock, OR CodeMirror 6 with custom HL7 mode (recommend the latter — gives you syntax highlighting + diagnostics gutter for free)
+3. **Inspector** — updates on cursor position; reads from existing field dictionary
+
+### Validation
+
+Re-use existing `validation.rs` rules. Run on every keystroke (debounce 200ms). Diagnostics → wavy underlines via CodeMirror's `linter` extension.
+
+### Keyboard
+
+- `⌘↵` / `Ctrl+↵` → Send to current target
+- `⌘S` → Save as template
+- `⌘⇧F` → Format (rewrite delimiters consistently)
+- `Esc` → Close (with unsaved-changes confirm)
+
+### API
+
+`POST /api/raw/send` — body is the raw HL7 + target ID, returns `MllpSendResult`. Same shape as replay endpoint.
+
+---
+
+## M4 · Task 4 — Smart notifications
+
+**Mockup:** Idea 4.
+
+Skip the "ping on every message" version — it's noise and users will turn it off. Build rule-based notifications instead.
+
+### Rules data model
+
+```rust
+struct NotificationRule {
+    id: Uuid,
+    name: String,
+    trigger: NotifTrigger,
+    enabled: bool,
+}
+
+enum NotifTrigger {
+    FilterMatch { query: String },           // matches search query syntax
+    ParseError,                              // any parse error
+    AckCode { codes: Vec<String> },          // AE / AR
+    Silence { duration_secs: u32 },          // no messages in N seconds
+    SourceDown { target_id: String },        // health check fails
+}
+```
+
+### UI
+
+- "+ Notify" button next to filter chips when a search has results.
+- Rules manager in settings: list of rules with enable toggle.
+- Browser `Notification.requestPermission()` on first rule creation.
+- In-app toast as fallback if permission denied.
+- Click → deep-link to filtered inbox view.
+
+### Implementation
+
+Single `tokio::spawn` rule evaluator. On every new message + every minute (for silence rules), iterate enabled rules, fire matches via WebSocket → frontend creates `new Notification(...)`.
+
+---
+
+## M5 · Task 1 — SQLite backend
+
+**Mockup:** Idea 5.
+
+### Config
+
+```toml
+[storage]
+backend = "sqlite"          # "memory" (default) | "sqlite" | "postgres"
+path = "~/.harux/messages.db"
+encryption_key_env = "HARUX_DB_KEY"   # SQLCipher; omit = unencrypted
+```
+
+### Schema
+
+```sql
+CREATE TABLE messages (
+    id TEXT PRIMARY KEY,
+    received_at INTEGER NOT NULL,         -- unix ms
+    source_addr TEXT NOT NULL,
+    message_type TEXT NOT NULL,
+    sending_facility TEXT,
+    patient_name TEXT,
+    patient_id TEXT,
+    message_control_id TEXT,
+    version TEXT,
+    segment_count INTEGER,
+    ack_code TEXT,
+    ack_response TEXT,
+    parse_error TEXT,
+    raw BLOB NOT NULL,
+    parsed_json TEXT,                      -- cached parse result
+    bookmarked INTEGER DEFAULT 0,
+    validation_warning_count INTEGER DEFAULT 0,
+    has_segment_errors INTEGER DEFAULT 0
+);
+
+CREATE INDEX idx_messages_received_at ON messages(received_at DESC);
+CREATE INDEX idx_messages_source ON messages(source_addr);
+CREATE INDEX idx_messages_bookmarked ON messages(bookmarked) WHERE bookmarked = 1;
+
+CREATE TABLE message_tags (
+    message_id TEXT REFERENCES messages(id) ON DELETE CASCADE,
+    tag TEXT NOT NULL,
+    PRIMARY KEY (message_id, tag)
+);
+
+CREATE TABLE schema_version (version INTEGER NOT NULL);
+INSERT INTO schema_version VALUES (1);
+```
+
+### Store trait
+
+Refactor `src/store.rs` to a trait and provide `MemoryStore` + `SqliteStore` implementations. The rest of the code talks to the trait. Keep the existing in-memory ring buffer as a write-through cache in front of SQLite for hot-path reads.
+
+### SQLCipher
+
+Use the `rusqlite` crate with the `sqlcipher` feature. On open, if `encryption_key_env` is set, `PRAGMA key = '<value>'` before any other statement.
+
+---
+
+## M5 · Task 2 — Retention policy
+
+**Mockup:** Idea 5 (retention bar visualization).
+
+### Config
+
+```toml
+[storage.retention]
+max_age_days = 14
+max_count = 50000
+keep_bookmarked = true       # bookmarked messages survive retention
+prune_interval_minutes = 60
+```
+
+### Pruner
+
+`tokio::spawn` task running every `prune_interval_minutes`:
+
+```sql
+DELETE FROM messages
+WHERE received_at < ?max_age_cutoff
+  AND (bookmarked = 0 OR ?keep_bookmarked = 0);
+
+DELETE FROM messages
+WHERE id IN (
+  SELECT id FROM messages
+  WHERE bookmarked = 0 OR ?keep_bookmarked = 0
+  ORDER BY received_at DESC
+  LIMIT -1 OFFSET ?max_count
+);
+
+VACUUM;     -- only if DELETEs > 1000 rows
+```
+
+Emit `{type: "pruned", count: N}` over WebSocket so the UI can refresh stats.
+
+### Settings UI
+
+Single page (`/settings/storage` route or modal). Components from mockup:
+
+- `.stat-strip` — 4 cards: stored messages, db size, oldest message, time-until-next-prune. All from `GET /api/storage/stats`.
+- `.setting-row` × 6 — backend, age limit, count limit, bookmark behavior, encryption, manual actions.
+- `.retention-viz` — horizontal bar showing oldest-message position relative to retention cutoff. Updates live as user drags the age input.
+
+```
+[oldest 5d 12h ━━━━━━━━━━━━░░░░░░░░░ prune at 14d]
+```
+
+### Manual actions
+
+- `POST /api/storage/prune` → runs prune now
+- `POST /api/storage/vacuum` → runs `VACUUM`
+- `POST /api/storage/wipe` → drops all messages (confirm dialog)
+
+---
+
+## M5 · Task 3 — Extended exports
+
+**Mockup:** Idea 6.
+
+### Format support
+
+Six formats, each as a card in the modal:
+
+| Ext | Format | Implementation |
+|---|---|---|
+| `.json` | Structured JSON array | already exists — keep as default |
+| `.hl7` | FHS/BHS-framed HL7 batch | concatenate raws with `FHS\|...\rBHS\|...\r<msg>\rBTS\|...\rFTS\|...` |
+| `.csv` | Summary | write columns: id, received_at, type, source, facility, patient_name, patient_id, control_id, ack, segment_count, has_warnings |
+| `.ndjson` | Newline-delimited JSON | one message per line, full structured form |
+| `.zip` | Per-message bundle | `<id>.hl7` files inside a zip, plus `manifest.json` |
+| `.harux` | Session bundle | tar/zip of `messages.ndjson` + `tags.json` + `bookmarks.json` + `meta.json` (re-importable) |
+
+### Anonymizer
+
+When "Anonymize PHI" toggle is on, run raws through:
+
+```rust
+fn anonymize(raw: &str) -> String {
+    // Replace consistently — same input MRN always maps to same fake MRN within a single export
+    // Use deterministic hash → faker output
+    // Targets: PID-3 (MRN), PID-5 (name), PID-11 (address), PID-13/14 (phone), PID-19 (SSN)
+}
+```
+
+Critical for sharing test fixtures externally.
+
+### API
+
+```
+POST /api/export
+{
+  "format": "hl7" | "json" | "csv" | "ndjson" | "zip" | "harux",
+  "filter": "has:errors source:epic.hospital.local",   // current search query
+  "include_validation": false,
+  "anonymize_phi": true,
+  "ids": ["..."]    // optional, takes precedence over filter
+}
+→ streamed binary response, Content-Disposition: attachment; filename="..."
+```
+
+### Import (for `.harux` bundles)
+
+`POST /api/import` accepts `.harux` files and re-creates messages with original IDs (idempotent — skips duplicates by `(source_addr, message_control_id)`). Round-trip parity is the contract.
+
+---
+
+## M5 · Task 4 — Post-restart context banner
+
+**Mockup:** Idea 7.
+
+When the inbox loads, if `messages.length > 0` AND no new messages have arrived since page load, show a top banner:
+
+```
+🌀 14,283 messages restored from disk · last activity 3m ago
+   Listener resumed on :2575 · oldest message 5d 12h old        [Dismiss]
+```
+
+Auto-dismiss on first new message arrival, or after 10s, or on click.
+
+DOM: re-use the empty-state styling but compact horizontal form. Insert above the message list, below the throughput band.
+
+---
+
+## What NOT to break
+
+- Existing WebSocket message protocol (`init`, `new_message`, `tags_updated`, `bookmark_toggled`, `lagged`, `cleared`)
+- Existing API surface — extend with new routes, don't repurpose old ones
+- The M1–M3 visual language — replay drawer, generator, editor all use the redesigned components (health pills, segment cards, ACK chips, source dots)
+- Diff-vs-pinned logic
+- Source color palette / `getSourceColor` algorithm
+- `harux.toml` backwards compat — new sections (`[targets.*]`, `[storage]`, `[storage.retention]`) are all optional
+
+---
+
+## Suggested ship order (high leverage first)
+
+1. **`[targets]` config + MLLP client module** — unlocks 3 features
+2. **Replay drawer** — most asked-for, simplest UI
+3. **SQLite backend** (no retention yet) — survival across restarts is the killer feature
+4. **Retention policy + settings page** — guards against unbounded growth
+5. **Export modal with all formats** — small, self-contained, high value for support workflows
+6. **Template generator** — biggest UI lift, but enormous testing payoff
+7. **Raw editor** — power user feature, last
+8. **Smart notifications** — quality-of-life, can ship anytime
+
+Replay + persistence (1+2+3) are the two transforms. They turn Harux from a viewer into a workbench.
+
+---
+
+## Open questions for the user
+
+- Confirm Orchestra-specific defaults: TLS on by default for replay targets? -> yes
+- PHI anonymization: should we ship a default field list, or require explicit configuration? -> configurable by user in UI.
+- Postgres backend: in scope for M5, or defer to a future milestone? -> No. Only sqlite for now.
+- Burst-send concurrency: serialize (one at a time) or parallel up to N? Affects ACK ordering in the UI. -> only 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "harux"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum 0.7.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harux"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Peter Paprotny"]
 description = "High-performance MLLP server with real-time Web UI"

--- a/harux-m4-m5-suggestions.html
+++ b/harux-m4-m5-suggestions.html
@@ -1,0 +1,1547 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Harux — Milestone 4 & 5 design suggestions</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg-0: #0b0d12;
+    --bg-1: #131620;
+    --bg-2: #1b1f2c;
+    --bg-3: #242938;
+    --bg-4: #2e3447;
+    --line: #262b3a;
+    --line-strong: #343a4f;
+    --fg-0: #e9ebf2;
+    --fg-1: #aab0c2;
+    --fg-2: #6e7388;
+    --fg-3: #4a4f64;
+    --accent: #7aa2ff;
+    --accent-2: #5a82e8;
+    --accent-bg: rgba(122,162,255,0.10);
+    --ok: #4fb98a;
+    --warn: #e5a54b;
+    --err: #ea6363;
+    --info: #6cc6e0;
+    --purple: #c78cff;
+    --mono: 'JetBrains Mono', ui-monospace, monospace;
+    --sans: 'Inter', system-ui, sans-serif;
+    --radius: 8px;
+  }
+  * { margin:0; padding:0; box-sizing:border-box; }
+  body {
+    font-family: var(--sans);
+    background: var(--bg-0);
+    color: var(--fg-0);
+    font-size: 13px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+  .page {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 48px 32px 96px;
+  }
+  .header {
+    margin-bottom: 48px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--line);
+  }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--accent);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+  }
+  h1 {
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 10px;
+  }
+  .lede {
+    color: var(--fg-1);
+    font-size: 14px;
+    max-width: 720px;
+  }
+
+  /* Section */
+  .milestone {
+    margin-bottom: 64px;
+  }
+  .milestone-head {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 6px;
+  }
+  .milestone-tag {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--accent);
+    background: var(--accent-bg);
+    border: 1px solid rgba(122,162,255,0.3);
+    padding: 2px 8px;
+    border-radius: 4px;
+  }
+  .milestone-title { font-size: 20px; font-weight: 600; letter-spacing: -0.01em; }
+  .milestone-desc { color: var(--fg-2); font-size: 13px; margin-bottom: 28px; }
+
+  .idea {
+    margin-bottom: 36px;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    background: var(--bg-1);
+    overflow: hidden;
+  }
+  .idea-head {
+    padding: 16px 22px;
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+  .idea-num {
+    width: 28px; height: 28px;
+    display: grid; place-items: center;
+    background: var(--bg-3);
+    border-radius: 6px;
+    font-family: var(--mono);
+    font-weight: 600;
+    font-size: 12px;
+    color: var(--fg-1);
+    flex-shrink: 0;
+  }
+  .idea-title { font-size: 15px; font-weight: 600; }
+  .idea-sub { color: var(--fg-2); font-size: 12px; margin-left: auto; }
+
+  .idea-body { padding: 22px; }
+  .idea-rationale {
+    color: var(--fg-1);
+    font-size: 13px;
+    margin-bottom: 18px;
+    max-width: 760px;
+  }
+  .idea-rationale code {
+    font-family: var(--mono);
+    background: var(--bg-2);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 11px;
+  }
+
+  /* Mock UI components */
+  .mock {
+    background: var(--bg-0);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  /* Mock — replay drawer */
+  .replay-drawer {
+    padding: 18px;
+  }
+  .replay-head {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 14px;
+  }
+  .replay-head h3 { font-size: 14px; }
+  .replay-head .x {
+    color: var(--fg-2); cursor: pointer;
+    width: 24px; height: 24px;
+    display: grid; place-items: center;
+    border-radius: 4px;
+  }
+  .replay-head .x:hover { background: var(--bg-3); color: var(--fg-0); }
+
+  .replay-source {
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-bottom: 14px;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .replay-source .label {
+    font-size: 10px;
+    text-transform: uppercase;
+    color: var(--fg-3);
+    letter-spacing: 0.06em;
+  }
+  .replay-source .v { font-family: var(--mono); color: var(--fg-0); }
+
+  .field-group { margin-bottom: 12px; }
+  .field-label {
+    display: block;
+    font-size: 11px;
+    color: var(--fg-2);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 6px;
+  }
+  .field-input, .field-select {
+    width: 100%;
+    height: 32px;
+    padding: 0 10px;
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    color: var(--fg-0);
+    font: inherit;
+    font-family: var(--mono);
+    font-size: 12px;
+    outline: none;
+  }
+  .field-input:focus, .field-select:focus { border-color: var(--accent-2); }
+
+  .target-row {
+    display: grid;
+    grid-template-columns: 1fr 110px;
+    gap: 8px;
+  }
+
+  .preset-pills {
+    display: flex; gap: 6px; flex-wrap: wrap;
+    margin-bottom: 12px;
+  }
+  .preset-pill {
+    padding: 4px 10px;
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--fg-1);
+    cursor: pointer;
+  }
+  .preset-pill.active {
+    background: var(--accent-bg);
+    color: var(--accent);
+    border-color: rgba(122,162,255,0.4);
+  }
+
+  .toggle-row {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 10px 12px;
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    margin-bottom: 8px;
+    font-size: 12px;
+  }
+  .toggle-row .desc { color: var(--fg-2); font-size: 11px; margin-top: 2px; }
+  .switch {
+    width: 32px; height: 18px;
+    background: var(--bg-3);
+    border-radius: 999px;
+    position: relative;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .switch::after {
+    content: ''; position: absolute;
+    top: 2px; left: 2px;
+    width: 14px; height: 14px;
+    background: var(--fg-2);
+    border-radius: 50%;
+    transition: all .15s;
+  }
+  .switch.on { background: rgba(122,162,255,0.25); }
+  .switch.on::after { left: 16px; background: var(--accent); }
+
+  .replay-footer {
+    display: flex; gap: 8px;
+    margin-top: 18px;
+    padding-top: 14px;
+    border-top: 1px solid var(--line);
+  }
+  .btn {
+    height: 32px;
+    padding: 0 14px;
+    border: 1px solid var(--line);
+    background: var(--bg-2);
+    color: var(--fg-0);
+    font: inherit;
+    font-size: 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .btn:hover { background: var(--bg-3); }
+  .btn.primary {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #0b0d12;
+    font-weight: 600;
+  }
+  .btn.primary:hover { background: #8db0ff; }
+  .btn.ghost { background: transparent; }
+  .btn.danger { color: var(--err); border-color: rgba(234,99,99,0.3); }
+
+  /* Result banner */
+  .result-banner {
+    margin-top: 14px;
+    padding: 10px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .result-banner.ok {
+    background: rgba(79,185,138,0.08);
+    border: 1px solid rgba(79,185,138,0.3);
+    color: var(--ok);
+  }
+  .result-banner .latency {
+    margin-left: auto;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--fg-2);
+  }
+
+  /* Mock — generator */
+  .generator {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    min-height: 420px;
+  }
+  .gen-sidebar {
+    background: var(--bg-1);
+    border-right: 1px solid var(--line);
+    padding: 12px 0;
+  }
+  .gen-section-title {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-3);
+    padding: 6px 16px;
+    margin-top: 8px;
+  }
+  .gen-template {
+    padding: 8px 16px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--fg-1);
+  }
+  .gen-template:hover { background: var(--bg-2); }
+  .gen-template.active {
+    background: var(--bg-3);
+    color: var(--fg-0);
+    border-left: 2px solid var(--accent);
+    padding-left: 14px;
+  }
+  .gen-template .code {
+    font-family: var(--mono);
+    color: var(--accent);
+    font-weight: 600;
+    font-size: 11px;
+  }
+  .gen-template .desc {
+    color: var(--fg-2);
+    font-size: 10px;
+  }
+
+  .gen-main {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+  }
+  .gen-toolbar {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .gen-tabs {
+    display: flex;
+    gap: 0;
+  }
+  .gen-tab {
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--fg-2);
+    border: none;
+    background: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    font: inherit;
+    margin-bottom: -10px;
+    padding-bottom: 12px;
+  }
+  .gen-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+  .gen-tab:hover { color: var(--fg-0); }
+  .gen-toolbar .right { margin-left: auto; display: flex; gap: 6px; align-items: center; }
+
+  .gen-form {
+    padding: 16px;
+    overflow-y: auto;
+  }
+  .gen-segment-card {
+    margin-bottom: 14px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .gen-seg-head {
+    background: var(--bg-2);
+    padding: 8px 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    border-bottom: 1px solid var(--line);
+  }
+  .gen-seg-head .name {
+    font-family: var(--mono);
+    font-weight: 700;
+    color: var(--accent);
+  }
+  .gen-seg-head .desc { color: var(--fg-2); font-size: 11px; }
+  .gen-seg-fields {
+    display: grid;
+    grid-template-columns: 100px 1fr;
+    background: var(--bg-1);
+  }
+  .gen-seg-fields > div {
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--line);
+    font-size: 12px;
+  }
+  .gen-seg-fields > div:nth-last-child(-n+2) { border-bottom: none; }
+  .gen-seg-fields .k {
+    font-family: var(--mono);
+    color: var(--fg-2);
+    font-size: 11px;
+    background: var(--bg-1);
+  }
+  .gen-seg-fields .v {
+    font-family: var(--mono);
+    color: var(--fg-0);
+    background: var(--bg-1);
+  }
+  .gen-seg-fields .v input {
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--fg-0);
+    font: inherit;
+    font-family: var(--mono);
+    font-size: 12px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    margin: -2px -6px;
+    outline: none;
+  }
+  .gen-seg-fields .v input:hover { border-color: var(--line); background: var(--bg-2); }
+  .gen-seg-fields .v input:focus { border-color: var(--accent-2); background: var(--bg-2); }
+  .gen-seg-fields .v.dyn input { color: var(--purple); }
+  .gen-seg-fields .v .dyn-tag {
+    display: inline-block;
+    margin-left: 6px;
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--purple);
+    background: rgba(199,140,255,0.1);
+    border: 1px solid rgba(199,140,255,0.3);
+    padding: 0 5px;
+    border-radius: 3px;
+  }
+
+  .gen-footer {
+    padding: 12px 16px;
+    background: var(--bg-1);
+    border-top: 1px solid var(--line);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .gen-footer .target {
+    flex: 1;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--fg-1);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .gen-footer .target .dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--ok);
+    box-shadow: 0 0 6px var(--ok);
+  }
+
+  /* Mock — editor */
+  .editor-wrap {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    min-height: 380px;
+  }
+  .editor-toolbar {
+    padding: 10px 16px;
+    background: var(--bg-1);
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .editor-toolbar .breadcrumb {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--fg-2);
+  }
+  .editor-toolbar .breadcrumb b { color: var(--fg-0); }
+  .editor-toolbar .right { margin-left: auto; display: flex; gap: 6px; }
+  .editor-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: var(--ok);
+    padding: 2px 8px;
+    background: rgba(79,185,138,0.08);
+    border: 1px solid rgba(79,185,138,0.3);
+    border-radius: 999px;
+  }
+  .editor-status.warn {
+    color: var(--warn);
+    background: rgba(229,165,75,0.08);
+    border-color: rgba(229,165,75,0.3);
+  }
+
+  .editor-body {
+    display: grid;
+    grid-template-columns: 36px 1fr 220px;
+    background: var(--bg-0);
+    font-family: var(--mono);
+    font-size: 12px;
+    line-height: 1.7;
+  }
+  .gutter {
+    background: var(--bg-1);
+    color: var(--fg-3);
+    text-align: right;
+    padding: 12px 8px;
+    user-select: none;
+    border-right: 1px solid var(--line);
+  }
+  .gutter > div { height: 1.7em; }
+  .gutter .marker {
+    color: var(--warn);
+    font-weight: 700;
+  }
+  .code-area {
+    padding: 12px 14px;
+    overflow-x: auto;
+    white-space: pre;
+    color: var(--fg-0);
+    position: relative;
+  }
+  .seg-name { color: var(--accent); font-weight: 600; }
+  .sep { color: var(--fg-3); }
+  .field-val { color: var(--fg-0); }
+  .field-empty { color: var(--fg-3); font-style: italic; }
+  .underline-warn {
+    text-decoration: underline wavy var(--warn);
+    text-underline-offset: 3px;
+  }
+
+  .inspector {
+    background: var(--bg-1);
+    border-left: 1px solid var(--line);
+    padding: 12px 14px;
+    font-family: var(--sans);
+  }
+  .inspector h4 {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-3);
+    margin-bottom: 8px;
+  }
+  .inspector .field-name {
+    font-family: var(--mono);
+    font-weight: 600;
+    color: var(--accent);
+    font-size: 13px;
+    margin-bottom: 2px;
+  }
+  .inspector .field-desc {
+    color: var(--fg-1);
+    font-size: 12px;
+    margin-bottom: 12px;
+  }
+  .inspector .meta {
+    font-size: 11px;
+    color: var(--fg-2);
+    line-height: 1.7;
+  }
+  .inspector .meta b { color: var(--fg-0); font-weight: 500; }
+  .inspector .hint {
+    margin-top: 12px;
+    padding: 8px 10px;
+    background: rgba(229,165,75,0.05);
+    border: 1px solid rgba(229,165,75,0.25);
+    border-radius: 5px;
+    font-size: 11px;
+    color: var(--warn);
+    line-height: 1.4;
+  }
+
+  /* Mock — persistence settings */
+  .settings-card {
+    padding: 18px 20px;
+  }
+  .setting-row {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 16px;
+    padding: 14px 0;
+    border-bottom: 1px solid var(--line);
+    align-items: start;
+  }
+  .setting-row:last-child { border-bottom: none; }
+  .setting-row .k { font-size: 13px; color: var(--fg-0); font-weight: 500; }
+  .setting-row .k .desc { color: var(--fg-2); font-size: 11px; font-weight: 400; margin-top: 3px; }
+  .setting-row .v { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+
+  .seg-control {
+    display: inline-flex;
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .seg-control button {
+    background: transparent;
+    border: none;
+    padding: 6px 12px;
+    color: var(--fg-1);
+    font: inherit;
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .seg-control button.active { background: var(--bg-4); color: var(--fg-0); }
+
+  .stat-strip {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+    margin-bottom: 18px;
+  }
+  .stat-card {
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 10px 12px;
+  }
+  .stat-card .l {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-3);
+    margin-bottom: 4px;
+  }
+  .stat-card .v {
+    font-family: var(--mono);
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--fg-0);
+  }
+  .stat-card .v.ok { color: var(--ok); }
+  .stat-card .v.warn { color: var(--warn); }
+
+  .retention-viz {
+    height: 28px;
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    overflow: hidden;
+    position: relative;
+    margin-top: 8px;
+  }
+  .retention-viz .filled {
+    height: 100%;
+    width: 62%;
+    background: linear-gradient(90deg, var(--accent-2), var(--accent));
+    border-right: 2px solid var(--warn);
+  }
+  .retention-viz .label {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--fg-0);
+    justify-content: space-between;
+  }
+
+  /* Export modal */
+  .export-modal {
+    padding: 20px;
+  }
+  .export-options {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    margin-bottom: 18px;
+  }
+  .export-opt {
+    padding: 14px;
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    cursor: pointer;
+    text-align: left;
+    transition: all .12s;
+  }
+  .export-opt:hover { border-color: var(--line-strong); }
+  .export-opt.selected {
+    border-color: var(--accent);
+    background: var(--accent-bg);
+  }
+  .export-opt .ext {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--accent);
+    margin-bottom: 4px;
+    font-weight: 600;
+  }
+  .export-opt .name { font-size: 13px; font-weight: 500; margin-bottom: 2px; }
+  .export-opt .desc { font-size: 11px; color: var(--fg-2); line-height: 1.4; }
+
+  .export-summary {
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 12px 14px;
+    font-size: 12px;
+    color: var(--fg-1);
+    line-height: 1.6;
+  }
+  .export-summary code {
+    font-family: var(--mono);
+    color: var(--fg-0);
+    background: var(--bg-1);
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+
+  /* Connection picker */
+  .conn-list {
+    background: var(--bg-1);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .conn-row {
+    display: grid;
+    grid-template-columns: 12px 1fr auto auto;
+    gap: 14px;
+    padding: 12px 16px;
+    align-items: center;
+    border-bottom: 1px solid var(--line);
+    cursor: pointer;
+  }
+  .conn-row:last-child { border-bottom: none; }
+  .conn-row:hover { background: var(--bg-2); }
+  .conn-row.default { background: rgba(122,162,255,0.04); }
+  .conn-row .light {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+  }
+  .conn-row .light.ok { background: var(--ok); box-shadow: 0 0 6px var(--ok); }
+  .conn-row .light.idle { background: var(--fg-3); }
+  .conn-row .light.err { background: var(--err); box-shadow: 0 0 6px var(--err); }
+  .conn-row .meta {
+    display: flex; flex-direction: column;
+  }
+  .conn-row .name { font-weight: 500; font-size: 13px; }
+  .conn-row .addr {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--fg-2);
+    margin-top: 2px;
+  }
+  .conn-row .latency {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--fg-2);
+  }
+  .conn-row .badge {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--accent);
+    background: var(--accent-bg);
+    padding: 2px 6px;
+    border-radius: 3px;
+  }
+
+  /* Notification banner */
+  .notif-mock {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+    max-width: 360px;
+  }
+  .notif-mock .icon {
+    width: 32px; height: 32px;
+    border-radius: 6px;
+    background: var(--accent-bg);
+    display: grid; place-items: center;
+    color: var(--accent);
+    flex-shrink: 0;
+  }
+  .notif-mock .body { flex: 1; min-width: 0; }
+  .notif-mock .title { font-size: 12px; font-weight: 600; margin-bottom: 1px; }
+  .notif-mock .sub { font-size: 11px; color: var(--fg-2); font-family: var(--mono); }
+
+  /* Annotations */
+  .annotations {
+    background: var(--bg-1);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-top: 16px;
+  }
+  .annotations ul { list-style: none; }
+  .annotations li {
+    font-size: 12px;
+    color: var(--fg-1);
+    padding: 4px 0 4px 18px;
+    position: relative;
+  }
+  .annotations li::before {
+    content: '→';
+    position: absolute;
+    left: 0;
+    color: var(--accent);
+  }
+  .annotations li b { color: var(--fg-0); font-weight: 500; }
+  .annotations li code {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--fg-0);
+    background: var(--bg-2);
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+
+  .icon-i { width: 14px; height: 14px; flex-shrink: 0; }
+
+  .twocol {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  @media (max-width: 980px) {
+    .twocol { grid-template-columns: 1fr; }
+    .generator { grid-template-columns: 1fr; }
+    .editor-body { grid-template-columns: 30px 1fr; }
+    .editor-body .inspector { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<div class="page">
+
+  <div class="header">
+    <div class="eyebrow">Harux · design exploration</div>
+    <h1>Milestones 4 & 5 — workflow, replay, persistence</h1>
+    <p class="lede">Concrete UI suggestions for the next two milestones. Each section: a working mock, the rationale, and bullet notes on the data wiring. Mocks are static — they show the shape, not the behavior.</p>
+  </div>
+
+  <!-- ─── M4 ─────────────────────────────────────────────────────── -->
+  <div class="milestone">
+    <div class="milestone-head">
+      <span class="milestone-tag">M4</span>
+      <span class="milestone-title">Workflow & Testing</span>
+    </div>
+    <div class="milestone-desc">Send · edit · replay against Orchestra (or any MLLP target) without leaving the inspector.</div>
+
+    <!-- Idea 1: Replay drawer -->
+    <div class="idea">
+      <div class="idea-head">
+        <div class="idea-num">1</div>
+        <div class="idea-title">Replay drawer — one-click resend with knobs</div>
+        <div class="idea-sub">addresses: replay task</div>
+      </div>
+      <div class="idea-body">
+        <div class="idea-rationale">
+          A right-side drawer that opens from a "Replay…" button in the detail header. The source message is locked at top (you can't accidentally replay the wrong one). Target picker is a dropdown of saved connections, not a free-form input — typing host:port every time is friction. Live ACK/latency feedback shown inline after send.
+        </div>
+
+        <div class="twocol">
+          <div class="mock replay-drawer">
+            <div class="replay-head">
+              <h3>Replay message</h3>
+              <div class="x">✕</div>
+            </div>
+
+            <div class="replay-source">
+              <span class="label">source</span>
+              <span class="v">ADT^A01</span>
+              <span style="color:var(--fg-3)">·</span>
+              <span class="v" style="color:var(--fg-1)">Romero, Marcus</span>
+              <span style="color:var(--fg-3)">·</span>
+              <span class="v">MSG00042185</span>
+            </div>
+
+            <div class="field-group">
+              <label class="field-label">Target connection</label>
+              <select class="field-select">
+                <option>Orchestra · staging · 10.4.1.22:6661</option>
+                <option>Orchestra · prod · orchestra.local:6661</option>
+                <option>localhost:2575 (self)</option>
+                <option>+ Add new target…</option>
+              </select>
+            </div>
+
+            <div class="field-group">
+              <label class="field-label">Modify before sending</label>
+              <div class="preset-pills">
+                <span class="preset-pill active">As-is</span>
+                <span class="preset-pill">Refresh MSH-7 (timestamp)</span>
+                <span class="preset-pill">New MSH-10 (control ID)</span>
+                <span class="preset-pill">Rewrite MRN…</span>
+              </div>
+            </div>
+
+            <div class="toggle-row">
+              <div>
+                <div>Wait for ACK</div>
+                <div class="desc">Capture the response, show inline.</div>
+              </div>
+              <div class="switch on"></div>
+            </div>
+            <div class="toggle-row">
+              <div>
+                <div>Tag replay in inbox</div>
+                <div class="desc">Adds <code>replay</code> + reference link.</div>
+              </div>
+              <div class="switch on"></div>
+            </div>
+
+            <div class="result-banner ok">
+              <svg class="icon-i" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>
+              <span>Replay sent · <strong style="color:var(--fg-0)">AA</strong> received from staging</span>
+              <span class="latency">42 ms</span>
+            </div>
+
+            <div class="replay-footer">
+              <button class="btn ghost">Cancel</button>
+              <button class="btn">Send & open response</button>
+              <button class="btn primary" style="margin-left:auto">
+                <svg class="icon-i" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 2 11 13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+                Replay
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <div class="conn-list">
+              <div style="padding:10px 16px; font-size:10px; text-transform:uppercase; letter-spacing:0.08em; color:var(--fg-3); border-bottom:1px solid var(--line); background:var(--bg-2)">Saved targets · settings</div>
+              <div class="conn-row default">
+                <span class="light ok"></span>
+                <div class="meta">
+                  <span class="name">Orchestra · staging</span>
+                  <span class="addr">10.4.1.22:6661 · TLS</span>
+                </div>
+                <span class="latency">~38ms</span>
+                <span class="badge">default</span>
+              </div>
+              <div class="conn-row">
+                <span class="light idle"></span>
+                <div class="meta">
+                  <span class="name">Orchestra · prod</span>
+                  <span class="addr">orchestra.local:6661 · TLS</span>
+                </div>
+                <span class="latency">~52ms</span>
+                <span></span>
+              </div>
+              <div class="conn-row">
+                <span class="light err"></span>
+                <div class="meta">
+                  <span class="name">Mirth (lab)</span>
+                  <span class="addr">mirth.dev:6660</span>
+                </div>
+                <span class="latency" style="color:var(--err)">refused</span>
+                <span></span>
+              </div>
+              <div class="conn-row">
+                <span class="light ok"></span>
+                <div class="meta">
+                  <span class="name">Self loopback</span>
+                  <span class="addr">localhost:2575</span>
+                </div>
+                <span class="latency">~1ms</span>
+                <span></span>
+              </div>
+            </div>
+            <div class="annotations">
+              <ul>
+                <li><b>Saved targets</b> live in <code>harux.toml</code> under <code>[targets.orchestra-staging]</code> — same shape as Postman environments.</li>
+                <li>Health check pings each target every 30s so the dropdown shows <code>~38ms</code> next to live ones, <code>refused</code> next to dead.</li>
+                <li>Default target gets the keyboard shortcut <code>R</code> from the message row — instant replay without opening the drawer.</li>
+                <li>"Replay" tagged messages get a small <code>↻ from MSG042185</code> link in their detail header.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Idea 2: Test message generator -->
+    <div class="idea">
+      <div class="idea-head">
+        <div class="idea-num">2</div>
+        <div class="idea-title">Template generator — pick a trigger, edit fields, fire</div>
+        <div class="idea-sub">addresses: test message generator</div>
+      </div>
+      <div class="idea-body">
+        <div class="idea-rationale">
+          Templates organized by category in a sidebar. The form is a structured field editor (not free-form HL7) so users don't have to remember segment delimiters. Fields with a <span style="color:var(--purple)">∼</span> tag are auto-generated on send (timestamp, control ID, UUIDs) — important for sending many messages without collisions. Switch to "Raw" tab for power users.
+        </div>
+
+        <div class="mock generator">
+          <div class="gen-sidebar">
+            <div class="gen-section-title">Patient admin · ADT</div>
+            <div class="gen-template active">
+              <div>
+                <div class="code">A01</div>
+                <div class="desc">Admit / visit notification</div>
+              </div>
+            </div>
+            <div class="gen-template">
+              <div>
+                <div class="code">A03</div>
+                <div class="desc">Discharge</div>
+              </div>
+            </div>
+            <div class="gen-template">
+              <div>
+                <div class="code">A08</div>
+                <div class="desc">Update patient info</div>
+              </div>
+            </div>
+            <div class="gen-section-title">Orders · ORM / OMG</div>
+            <div class="gen-template">
+              <div>
+                <div class="code">ORM^O01</div>
+                <div class="desc">Order message</div>
+              </div>
+            </div>
+            <div class="gen-template">
+              <div>
+                <div class="code">OMG^O19</div>
+                <div class="desc">General clinical order</div>
+              </div>
+            </div>
+            <div class="gen-section-title">Results · ORU</div>
+            <div class="gen-template">
+              <div>
+                <div class="code">ORU^R01</div>
+                <div class="desc">Unsolicited observation</div>
+              </div>
+            </div>
+            <div class="gen-section-title">Custom</div>
+            <div class="gen-template" style="color:var(--fg-2)">
+              <div>
+                <div class="code" style="color:var(--fg-2)">+ New from received…</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="gen-main">
+            <div class="gen-toolbar">
+              <div class="gen-tabs">
+                <button class="gen-tab active">Form</button>
+                <button class="gen-tab">Raw HL7</button>
+                <button class="gen-tab">Preview</button>
+              </div>
+              <div class="right">
+                <button class="btn">Sample faker data</button>
+                <button class="btn">Save as preset</button>
+              </div>
+            </div>
+
+            <div class="gen-form">
+              <div class="gen-segment-card">
+                <div class="gen-seg-head">
+                  <span class="name">MSH</span>
+                  <span class="desc">Message header</span>
+                </div>
+                <div class="gen-seg-fields">
+                  <div class="k">MSH-3</div>
+                  <div class="v"><input value="HARUX_TEST" /></div>
+                  <div class="k">MSH-4</div>
+                  <div class="v"><input value="HARUX.LAB" /></div>
+                  <div class="k">MSH-7</div>
+                  <div class="v dyn"><input value="20260508.140321" /><span class="dyn-tag">∼ now</span></div>
+                  <div class="k">MSH-9</div>
+                  <div class="v"><input value="ADT^A01^ADT_A01" /></div>
+                  <div class="k">MSH-10</div>
+                  <div class="v dyn"><input value="MSG_a4b2c1f8" /><span class="dyn-tag">∼ uuid</span></div>
+                  <div class="k">MSH-11</div>
+                  <div class="v"><input value="T" /></div>
+                </div>
+              </div>
+
+              <div class="gen-segment-card">
+                <div class="gen-seg-head">
+                  <span class="name">PID</span>
+                  <span class="desc">Patient identification</span>
+                </div>
+                <div class="gen-seg-fields">
+                  <div class="k">PID-3</div>
+                  <div class="v"><input value="MRN-78421^^^MGH^MR" /></div>
+                  <div class="k">PID-5</div>
+                  <div class="v"><input value="Romero^Marcus^J" /></div>
+                  <div class="k">PID-7</div>
+                  <div class="v"><input value="19840712" /></div>
+                  <div class="k">PID-8</div>
+                  <div class="v"><input value="M" /></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="gen-footer">
+              <span class="target">
+                <span class="dot"></span>
+                Send to <strong>Orchestra · staging</strong>
+                <span style="color:var(--fg-3)">10.4.1.22:6661</span>
+              </span>
+              <button class="btn">Send 1</button>
+              <button class="btn">Send <input style="width:36px; height:20px; background:var(--bg-1); border:1px solid var(--line); color:var(--fg-0); font:inherit; font-family:var(--mono); font-size:11px; padding:0 4px; border-radius:3px; outline:none; text-align:center" value="50" /></button>
+              <button class="btn primary">
+                <svg class="icon-i" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 2 11 13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+                Send & watch
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="annotations">
+          <ul>
+            <li>Templates ship as <code>.hl7</code> files in <code>examples/templates/</code> — users can drop their own in and they appear in the sidebar.</li>
+            <li><b>"+ New from received"</b> turns any inbox message into a saved template — captures the whole structure as a starting point.</li>
+            <li><b>Dynamic tags</b> (<code>∼ now</code>, <code>∼ uuid</code>, <code>∼ faker.name</code>) re-evaluate per-send. Critical when burst-sending — every message gets a unique MSH-10.</li>
+            <li><b>"Send 50"</b> burst mode for load testing. Progress bar + per-message ACK summary appears as a transient panel.</li>
+            <li>Orchestra-specific: pre-shipped templates that match their accepted profiles (PID-3 with their assigning authority, MSH-21 conformance profile).</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Idea 3: Raw editor -->
+    <div class="idea">
+      <div class="idea-head">
+        <div class="idea-num">3</div>
+        <div class="idea-title">Raw editor — HL7 with live validation gutter</div>
+        <div class="idea-sub">addresses: message editor</div>
+      </div>
+      <div class="idea-body">
+        <div class="idea-rationale">
+          A monospace text area with line numbers and a right-side inspector that updates as you click into fields. Wavy underlines mark validation issues live. <code>⌘↵</code> sends. The whole thing opens fullscreen via "Edit raw…" on any inbox message — pre-filled with the source.
+        </div>
+
+        <div class="mock editor-wrap">
+          <div class="editor-toolbar">
+            <span class="breadcrumb">editor · forked from <b>MSG00042185</b></span>
+            <span class="editor-status warn">
+              <svg class="icon-i" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+              1 warning
+            </span>
+            <div class="right">
+              <button class="btn">Format</button>
+              <button class="btn">Validate</button>
+              <button class="btn primary">
+                Send to staging
+                <span style="font-family:var(--mono); font-size:10px; background:rgba(0,0,0,0.2); padding:1px 5px; border-radius:3px; margin-left:4px">⌘↵</span>
+              </button>
+            </div>
+          </div>
+
+          <div class="editor-body">
+            <div class="gutter">
+              <div>1</div>
+              <div>2</div>
+              <div>3</div>
+              <div class="marker">4 ⚠</div>
+              <div>5</div>
+              <div>6</div>
+              <div>7</div>
+              <div>8</div>
+            </div>
+            <div class="code-area"><span class="seg-name">MSH</span><span class="sep">|^~\&|</span>EPIC<span class="sep">|</span>EPIC.MGH<span class="sep">|</span>HARUX<span class="sep">|</span>HARUX.LAB<span class="sep">|</span>20260508140321<span class="sep">||</span>ADT^A01^ADT_A01<span class="sep">|</span>MSG00042185<span class="sep">|</span>P<span class="sep">|</span>2.5.1
+<span class="seg-name">EVN</span><span class="sep">|</span>A01<span class="sep">|</span>20260508140321
+<span class="seg-name">PID</span><span class="sep">|</span>1<span class="sep">||</span>MRN-78421^^^MGH^MR<span class="sep">||</span>Romero^Marcus^J^^Mr.<span class="sep">||</span>19840712<span class="sep">|</span>M
+<span class="seg-name">PD1</span><span class="sep">|||</span><span class="underline-warn"><span class="field-empty">(missing)</span></span><span class="sep">|</span>PCP-1109^Reyes^Daniel
+<span class="seg-name">NK1</span><span class="sep">|</span>1<span class="sep">|</span>Romero^Elena^M<span class="sep">|</span>SPO
+<span class="seg-name">PV1</span><span class="sep">|</span>1<span class="sep">|</span>I<span class="sep">|</span>7E^702^A^MGH<span class="sep">|||||</span>1234^Patel^Anjali
+<span class="seg-name">DG1</span><span class="sep">|</span>1<span class="sep">||</span>I10:J18.9<span class="sep">|</span>Pneumonia
+<span class="seg-name">AL1</span><span class="sep">|</span>1<span class="sep">|</span>DA<span class="sep">|</span>Penicillin<span class="sep">|</span>SV</div>
+
+            <div class="inspector">
+              <h4>Field inspector</h4>
+              <div class="field-name">PD1-3</div>
+              <div class="field-desc">Patient primary facility</div>
+              <div class="meta">
+                <div><b>Type</b> XON (composite)</div>
+                <div><b>Required</b> conditional</div>
+                <div><b>Length</b> ≤ 250</div>
+                <div><b>Repeats</b> 0..*</div>
+              </div>
+              <div class="hint">
+                <strong>Required for ADT^A01</strong> per Orchestra profile. Suggested: <code>MGH^^4815</code>.
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="annotations">
+          <ul>
+            <li>Cursor in the code area updates the inspector live — uses your existing field dictionary.</li>
+            <li><b>"Format"</b> rewrites the message with consistent delimiters and aligned columns (debugging aid).</li>
+            <li><b>"Validate"</b> runs the same rules as the inbox validation — same warnings list appears.</li>
+            <li>On send, the response opens in a transient pane below the editor; if AE/AR, jumps cursor to the field referenced in the ACK error.</li>
+            <li>Saved drafts persist in <code>localStorage</code>; "Send to inbox (loopback)" is also an option for testing Harux's own parser.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Idea 4: Notifications -->
+    <div class="idea">
+      <div class="idea-head">
+        <div class="idea-num">4</div>
+        <div class="idea-title">Smart notifications — not "new message" spam</div>
+        <div class="idea-sub">addresses: auto-refresh trigger / desktop notification</div>
+      </div>
+      <div class="idea-body">
+        <div class="idea-rationale">
+          A desktop notification on every message is noise. Make it triggerable: notify only when a watched filter matches. "Notify me on parse errors", "notify me when I get a message tagged <code>followup</code>", "notify me when this MRN appears". Configurable from the same chip-style filter UI.
+        </div>
+
+        <div class="twocol">
+          <div class="notif-mock">
+            <div class="icon">
+              <svg class="icon-i" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.3 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.7 3.86a2 2 0 00-3.4 0z"/><line x1="12" y1="9" x2="12" y2="13"/></svg>
+            </div>
+            <div class="body">
+              <div class="title">Parse error from epic.hospital.local</div>
+              <div class="sub">ADT^A01 · Malformed MSH segment</div>
+            </div>
+          </div>
+
+          <div class="notif-mock">
+            <div class="icon" style="background:rgba(229,165,75,0.1); color:var(--warn)">
+              <svg class="icon-i" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+            </div>
+            <div class="body">
+              <div class="title">No messages received in 5 min</div>
+              <div class="sub">Listener still up — sender may be down</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="annotations">
+          <ul>
+            <li>Notification rules live next to the filter chips: <code>+ Notify on this filter</code> appears when a search has matches.</li>
+            <li><b>Silence</b> rule by default — "no messages in N minutes" catches the common "is the integration broken?" question.</li>
+            <li>Click on a notification deep-links to the matching message in the Harux UI.</li>
+            <li>Browser <code>Notification.requestPermission()</code> on first rule creation; falls back to in-app toast.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ─── M5 ─────────────────────────────────────────────────────── -->
+  <div class="milestone">
+    <div class="milestone-head">
+      <span class="milestone-tag">M5</span>
+      <span class="milestone-title">Persistence</span>
+    </div>
+    <div class="milestone-desc">Survive restarts, prune sensibly, export anything.</div>
+
+    <!-- Idea 5: Persistence settings -->
+    <div class="idea">
+      <div class="idea-head">
+        <div class="idea-num">5</div>
+        <div class="idea-title">Storage settings — single page, visual retention</div>
+        <div class="idea-sub">addresses: SQLite backend + retention policy</div>
+      </div>
+      <div class="idea-body">
+        <div class="idea-rationale">
+          Persistence defaults to off (current behavior). One settings page exposes the toggle, the location, and the retention policy. The retention bar shows live what's about to be pruned — way clearer than just a number. Live stats card at the top: how big is my db, how many messages, how full is the retention window.
+        </div>
+
+        <div class="mock settings-card">
+          <div class="stat-strip">
+            <div class="stat-card">
+              <div class="l">stored messages</div>
+              <div class="v">14,283</div>
+            </div>
+            <div class="stat-card">
+              <div class="l">db size</div>
+              <div class="v">128 MB</div>
+            </div>
+            <div class="stat-card">
+              <div class="l">oldest</div>
+              <div class="v">5d 12h ago</div>
+            </div>
+            <div class="stat-card">
+              <div class="l">next prune</div>
+              <div class="v ok">in 11h</div>
+            </div>
+          </div>
+
+          <div class="setting-row">
+            <div class="k">
+              Persistence
+              <div class="desc">Survive server restarts. Stored at <code style="font-size:11px">~/.harux/messages.db</code>.</div>
+            </div>
+            <div class="v">
+              <div class="seg-control">
+                <button>Off</button>
+                <button class="active">SQLite (local)</button>
+                <button>Postgres</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="setting-row">
+            <div class="k">
+              Retention by age
+              <div class="desc">Delete messages older than this on every prune cycle.</div>
+            </div>
+            <div class="v" style="flex-direction:column; align-items:stretch; gap:4px;">
+              <div style="display:flex; gap:8px; align-items:center;">
+                <input class="field-input" style="width:80px;" value="14" />
+                <select class="field-select" style="width:auto; min-width:100px;">
+                  <option>days</option>
+                  <option>hours</option>
+                  <option>weeks</option>
+                </select>
+              </div>
+              <div class="retention-viz">
+                <div class="filled"></div>
+                <div class="label">
+                  <span>5d 12h oldest</span>
+                  <span style="color:var(--warn)">prune at 14d</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="setting-row">
+            <div class="k">
+              Retention by count
+              <div class="desc">Keep at most this many messages — overrides age if smaller.</div>
+            </div>
+            <div class="v">
+              <input class="field-input" style="width:120px;" value="50,000" />
+              <span style="color:var(--fg-2); font-size:11px">≈ 250 MB at current avg size</span>
+            </div>
+          </div>
+
+          <div class="setting-row">
+            <div class="k">
+              Bookmarked messages
+              <div class="desc">Pinned messages can survive retention.</div>
+            </div>
+            <div class="v">
+              <div class="seg-control">
+                <button>Same as others</button>
+                <button class="active">Never auto-delete</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="setting-row">
+            <div class="k">
+              Encryption at rest
+              <div class="desc">Encrypts the SQLite db (SQLCipher). Required for PHI in many setups.</div>
+            </div>
+            <div class="v">
+              <div class="switch on"></div>
+              <span style="color:var(--fg-2); font-size:11px">Key derived from <code style="font-size:11px">HARUX_DB_KEY</code> env var.</span>
+            </div>
+          </div>
+
+          <div class="setting-row">
+            <div class="k">
+              Manual actions
+              <div class="desc"></div>
+            </div>
+            <div class="v">
+              <button class="btn">Run prune now</button>
+              <button class="btn">Vacuum db</button>
+              <button class="btn danger">Wipe all stored messages</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="annotations">
+          <ul>
+            <li>Retention bar is the killer feature — when you adjust the slider, you see immediately which messages would be deleted. Less anxiety than blind numbers.</li>
+            <li><b>Bookmarks-survive-retention</b> is a small but high-value detail: lets users pin "interesting" messages without setting up complex queries.</li>
+            <li><b>SQLCipher</b> is a single-line addition over plain SQLite and unlocks healthcare deployments.</li>
+            <li>Storage backend is pluggable — Postgres option matters for multi-instance Harux deployments.</li>
+            <li>Stats cards link to the existing top-bar health pills design language.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Idea 6: Export modal -->
+    <div class="idea">
+      <div class="idea-head">
+        <div class="idea-num">6</div>
+        <div class="idea-title">Export — formats with purpose, scoped to current filter</div>
+        <div class="idea-sub">addresses: extended export</div>
+      </div>
+      <div class="idea-body">
+        <div class="idea-rationale">
+          Each format is for a different audience. Cards explain when to use each, instead of a bare dropdown. The export <em>scope</em> always reflects the current filter — clear summary at the bottom: "you're exporting 42 messages matching <code>has:errors</code> from epic.hospital.local".
+        </div>
+
+        <div class="mock export-modal">
+          <h3 style="font-size:15px; margin-bottom:14px;">Export messages</h3>
+
+          <div class="export-options">
+            <div class="export-opt">
+              <div class="ext">.json</div>
+              <div class="name">Structured JSON</div>
+              <div class="desc">Full parsed segments, metadata, ACK, validation. For programmatic use.</div>
+            </div>
+            <div class="export-opt selected">
+              <div class="ext">.hl7</div>
+              <div class="name">Raw HL7 batch</div>
+              <div class="desc">Original wire format, FHS/BHS framed. Replay-able into any HL7 engine.</div>
+            </div>
+            <div class="export-opt">
+              <div class="ext">.csv</div>
+              <div class="name">CSV summary</div>
+              <div class="desc">One row per message: type, patient, source, time, ACK. For spreadsheets.</div>
+            </div>
+            <div class="export-opt">
+              <div class="ext">.ndjson</div>
+              <div class="name">Newline-delimited JSON</div>
+              <div class="desc">Streamable. Pipe into <code>jq</code>, log shippers, or kafka producers.</div>
+            </div>
+            <div class="export-opt">
+              <div class="ext">.zip</div>
+              <div class="name">One file per message</div>
+              <div class="desc">Each message as a separate <code>.hl7</code> file — for fixture libraries.</div>
+            </div>
+            <div class="export-opt">
+              <div class="ext">.har-ish</div>
+              <div class="name">Harux session bundle</div>
+              <div class="desc">Everything: messages + ACKs + tags + bookmarks. Re-importable into Harux.</div>
+            </div>
+          </div>
+
+          <div class="export-summary">
+            <strong style="color:var(--fg-0)">Exporting 42 messages</strong> matching current filter:
+            <code>has:errors source:epic.hospital.local</code>.
+            Includes raw + parsed + ACKs.
+            Estimated size: <strong style="color:var(--fg-0)">~340 KB</strong>.
+          </div>
+
+          <div class="replay-footer" style="margin-top: 16px; padding-top: 0; border-top: none;">
+            <label style="display:flex; align-items:center; gap:6px; font-size:12px; color:var(--fg-1);">
+              <input type="checkbox" /> Include validation warnings
+            </label>
+            <label style="display:flex; align-items:center; gap:6px; font-size:12px; color:var(--fg-1);">
+              <input type="checkbox" checked /> Anonymize PHI
+            </label>
+            <button class="btn ghost" style="margin-left:auto">Cancel</button>
+            <button class="btn primary">
+              <svg class="icon-i" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+              Export
+            </button>
+          </div>
+        </div>
+
+        <div class="annotations">
+          <ul>
+            <li><b>"Anonymize PHI"</b> toggle: replaces patient names / MRNs / addresses with consistent fakes (Faker.js) before writing. Huge for sharing test fixtures.</li>
+            <li><b>Harux session bundle</b> (<code>.har-ish</code>) round-trips: import a colleague's bundle and see exactly what they saw, with their tags and bookmarks intact. Killer feature for support/debugging.</li>
+            <li><b>Per-message zip</b> turns Harux into a fixture-generator for your test suite — no more hand-curating `.hl7` files in <code>tests/messages/</code>.</li>
+            <li>Format cards make this self-documenting; new users discover capabilities without docs.</li>
+            <li>Footer summary always reflects the current filter — no surprise giant exports.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Idea 7: Restart banner -->
+    <div class="idea">
+      <div class="idea-head">
+        <div class="idea-num">7</div>
+        <div class="idea-title">Post-restart context — show what survived</div>
+        <div class="idea-sub">addresses: persistence acceptance criteria</div>
+      </div>
+      <div class="idea-body">
+        <div class="idea-rationale">
+          When persistence is on and the server restarts, messages reappear — but the user might not realize they're looking at "old" data vs "live". Show a small contextual banner above the inbox the first time it loads: "Restored 14,283 messages from disk · last activity 3m ago". Self-dismisses after 10s or on first new message.
+        </div>
+
+        <div class="mock" style="padding:12px 16px; display:flex; align-items:center; gap:12px;">
+          <svg class="icon-i" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2" style="width:18px; height:18px;"><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/><path d="M3 12c4 0 4-4 8-4s4 4 8 4"/></svg>
+          <div style="flex:1;">
+            <div style="font-size:13px; color:var(--fg-0);"><strong>14,283 messages restored</strong> from disk · last activity 3m ago</div>
+            <div style="font-size:11px; color:var(--fg-2); margin-top:2px;">Listener resumed on :2575 · oldest message 5d 12h old</div>
+          </div>
+          <button class="btn ghost" style="height:28px;">Dismiss</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- Footer -->
+  <div style="margin-top: 64px; padding-top: 32px; border-top: 1px solid var(--line); color: var(--fg-2); font-size: 12px; line-height: 1.7;">
+    <strong style="color:var(--fg-0); display:block; margin-bottom:6px;">Implementation order suggestion</strong>
+    1. Saved targets in <code style="font-family:var(--mono); background:var(--bg-2); padding:1px 5px; border-radius:3px;">harux.toml</code> (M4 prereq) →
+    2. Replay drawer →
+    3. SQLite backend + retention (M5 core) →
+    4. Export modal →
+    5. Template generator →
+    6. Raw editor →
+    7. Smart notifications.
+    <br><br>
+    Replay + persistence are the two highest-leverage items: replay turns Harux into a Postman for HL7, persistence turns it into a debugging journal you can come back to.
+  </div>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Cuts the **v0.5.0** release.

- Bumps `Cargo.toml` from `0.4.0` → `0.5.0` (and `Cargo.lock` follows).
- Promotes `[Unreleased]` CHANGELOG section to `[0.5.0] – 2026-05-08 – UI Redesign` with a one-line summary line.
- Moves the dated commit-history table from `[0.4.0]` to the new `[0.5.0]` section so each release lists its own commits.
- Adds fresh empty `[Unreleased]` block above `[0.5.0]`.
- Updates bottom-of-file link references for v0.5.0 / v0.4.0 / v0.3.0.

## What's in v0.5.0

- **Six-phase frontend redesign** per `CLAUDE_CODE_HANDOFF.md` (typography + colors, top-bar health pills, two-line message rows with sticky time grouping and ACK chips, always-visible source rail + 60-bar throughput band, detail-panel restructure, empty-state CLI hint + polish pass).
- **Chrome cleanup follow-up** (#105) — list-scoped controls move into the new `.inbox-controls` row under the search bar; topbar gains `total` / `validation` / `parse errors` pills; redundant throughput band removed (sparkline lives in the rate pill).
- **a11y wins**: row keyboard navigation, ARIA labels, native buttons, global `:focus-visible` outline, `⌘K` shortcut.
- **Two perf wins on top**: parser Vec-allocation reduction (#102) and frontend search filter memoization (#100/#104).

No protocol, API, or storage changes. Session keys (`harux_session`, `_state`) and saved fields keep their meanings.

## Post-merge release plan

1. Tag `v0.5.0` on the merge commit and push: `git tag v0.5.0 && git push origin v0.5.0`.
2. Create the GitHub release: `gh release create v0.5.0 --title "v0.5.0 — UI Redesign" --notes-from-tag` (or paste the CHANGELOG section).
3. The existing `Build & Release` workflow (`.github/workflows/build.yml`) attaches Windows / macOS Apple Silicon / Linux binaries to the release on `release: published`.

## Test plan

- [ ] CI: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test`
- [ ] Manual: confirm `Cargo.toml` reads `version = "0.5.0"`.
- [ ] Manual: confirm `Cargo.lock` is updated.
- [ ] Manual: confirm CHANGELOG `[Unreleased]` is empty and `[0.5.0]` contains all redesign + perf entries.
- [ ] Manual: post-merge tag the merge commit `v0.5.0` and publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)