### PR TITLE
🎨 Palette: Keyboard Accessibility for Custom Interactive Elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-08 - Added keyboard accessibility to custom list items
 **Learning:** When using `div` elements as clickable rows in a list, setting `onclick` is not enough for keyboard accessibility. Screen reader and keyboard-only users cannot interact with them.
 **Action:** Always add `tabIndex="0"`, `role="button"`, an `onkeydown` handler for 'Enter'/'Space', and a `:focus-visible` CSS pseudo-class to ensure custom interactive elements are fully accessible.
+
+## 2026-05-09 - Added keyboard accessibility to standard UI components (spans/divs acting as buttons)
+**Learning:** `div` and `span` elements that use `onclick` handlers inside app lists, headers, or custom tables don't automatically receive focus or trigger on keyboard interaction. Using click listeners and missing `aria-label` degrades experience for keyboard users.
+**Action:** Consistently ensure that all custom interactive components (like `.segment-name`, `.copy-btn`, and `.field-val`) have `tabindex="0"`, `role="button"`, proper `aria-*` state, and either global or inline keyboard event listeners (like 'Enter'/'Space') to trigger their associated actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 ## [Unreleased]
 
+### Added
+- **Keyboard accessibility for custom elements** — added `tabindex`, `role="button"`, and Enter/Space keyboard activation for segment headers, copy buttons, field value cells, and tagging elements.
+
+### Commit History (chronological)
+
+#### 2026-05-09
+
+| Commit | Description |
+|--------|-------------|
+| [`51ca703`](https://github.com/Pappet/harux/commit/51ca703) | `feat(a11y):` add keyboard accessibility to custom UI elements |
+
 ---
 
 ## [0.5.0] – 2026-05-08 – UI Redesign

--- a/static/app.js
+++ b/static/app.js
@@ -904,12 +904,12 @@ function renderDetail() {
     const pinLabel = isPinned ? 'Pinned' : 'Pin diff';
 
     const tagChipsHtml = (msg.tags || []).map(t =>
-        `<span class="msg-tag">${esc(t)}<span class="msg-tag-remove" onclick="removeTag('${msg.id}', '${escAttr(escJS(t))}')" title="Remove tag" aria-label="Remove tag">${ICONS.xMark}</span></span>`
+        `<span class="msg-tag">${esc(t)}<span class="msg-tag-remove" role="button" tabindex="0" onclick="removeTag('${msg.id}', '${escAttr(escJS(t))}')" onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); removeTag('${msg.id}', '${escAttr(escJS(t))}'); }" title="Remove tag" aria-label="Remove tag">${ICONS.xMark}</span></span>`
     ).join('');
     const tagAddHtml = `
         <div class="msg-tag-add">
-            <input type="text" id="add-tag-input" placeholder="Add tag" onkeypress="if(event.key === 'Enter') addTag('${msg.id}', this.value)">
-            <button onclick="addTag('${msg.id}', document.getElementById('add-tag-input').value)">+</button>
+            <input type="text" id="add-tag-input" placeholder="Add tag" aria-label="Add tag" onkeypress="if(event.key === 'Enter') addTag('${msg.id}', this.value)">
+            <button onclick="addTag('${msg.id}', document.getElementById('add-tag-input').value)" aria-label="Submit tag">+</button>
         </div>
     `;
 
@@ -1093,11 +1093,11 @@ function renderTab() {
             const warnFields = missingFieldByseg.get(seg.name);
             return `
             <div class="segment-block">
-                <div class="segment-name ${seg.description ? 'has-seg-tooltip' : ''}" data-seg-key="${key}"${seg.description ? ` data-desc="${escAttr(seg.name + ': ' + seg.description)}"` : ''}>
+                <div class="segment-name ${seg.description ? 'has-seg-tooltip' : ''}" data-seg-key="${key}"${seg.description ? ` data-desc="${escAttr(seg.name + ': ' + seg.description)}"` : ''} role="button" tabindex="0" aria-expanded="${!collapsed}">
                     <span class="collapse-icon">${icon}</span>
                     ${esc(seg.name)}
                     <span class="field-count">(${seg.fields.length})</span>
-                    <span class="copy-btn" onclick="event.stopPropagation(); copySegment(${segIdx}, this)" title="Copy segment">${ICONS.copy}</span>
+                    <span class="copy-btn" onclick="event.stopPropagation(); copySegment(${segIdx}, this)" title="Copy segment" role="button" tabindex="0" aria-label="Copy segment">${ICONS.copy}</span>
                 </div>
                 ${collapsed ? '' : `<table class="field-table">
                     <tbody>
@@ -1107,7 +1107,7 @@ function renderTab() {
                 return `
                         <tr${trCls}>
                             <td class="field-idx">${esc(seg.name)}-${f.index}${descLine}</td>
-                            <td class="field-val">${esc(f.value) || '<span class="field-empty">empty</span>'}</td>
+                            <td class="field-val" ${f.value ? 'role="button" tabindex="0" aria-label="Copy field value"' : ''}>${esc(f.value) || '<span class="field-empty">empty</span>'}</td>
                             <td class="field-components">${f.components.length > 1
                         ? f.components.map((c, i) => `<span title="${escAttr(seg.name + '-' + f.index + '.' + (i + 1))}">${esc(c)}</span>`).join(' <span style="color:var(--text-muted)">^</span> ')
                         : ''
@@ -1572,13 +1572,35 @@ document.getElementById('search-input').addEventListener('input', (e) => {
     }, 300);
 });
 
-document.addEventListener('click', (e) => {
+function handleInteraction(e) {
+    const copyBtn = e.target.closest('.copy-btn');
+    if (e.type === 'keydown' && copyBtn) {
+        e.preventDefault();
+        copyBtn.click();
+        return;
+    }
+
     const segEl = e.target.closest('.segment-name');
-    if (segEl) toggleSegment(segEl.dataset.segKey);
+    if (segEl && !copyBtn) toggleSegment(segEl.dataset.segKey);
 
     const cell = e.target.closest('.field-val');
     if (cell && !cell.querySelector('.field-empty')) {
         copyToClipboard(cell.textContent.trim(), cell);
+    }
+}
+
+document.addEventListener('click', handleInteraction);
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+        const activeEl = document.activeElement;
+        if (activeEl && (activeEl.classList.contains('segment-name') || activeEl.classList.contains('field-val') || activeEl.classList.contains('copy-btn'))) {
+            e.preventDefault();
+            handleInteraction({
+                target: activeEl,
+                type: 'keydown',
+                preventDefault: () => e.preventDefault()
+            });
+        }
     }
 });
 


### PR DESCRIPTION
As Palette 🎨, I observed that several interactive UI components acting as buttons (such as the segment headers, copy buttons, field value cells, and tagging elements) were only bound to mouse `click` events without native keyboard focus (`tabindex`) or `role="button"` attributes.

I've implemented a micro-UX enhancement by adding the necessary accessibility attributes and keydown handlers so that keyboard and screen-reader users can successfully navigate and interact with these elements. I also recorded this critical learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [5809273735728049182](https://jules.google.com/task/5809273735728049182) started by @Pappet*