### PR TITLE
Refactor: Split parse_message into composable passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **Keyboard accessibility for source chips** — added `tabindex="0"`, `role="button"`, and Enter/Space keyboard activation for source chips in the message list header, allowing filter toggling via keyboard navigation.
 
 ### Changed
+- **Refactor — parser modularization** — split the monolithic `parse_message` function into composable passes (`parse_structure`, `enrich_msh`, `enrich_pid`, `inject_descriptions`, `annotate_message_type`, `validate`) making it easier to test and extend. (#122)
 - **Performance — background store eviction** — moved the store eviction scan out of the `insert` hot path and into a background Tokio task, driven by a `Notify` trigger. This eliminates `MessageStore` write-lock contention under heavy loads, ensuring concurrent readers (WebSocket, search, HTTP API) no longer stall during eviction. (#130)
 - **Performance — detail panel DOM builders** — replaced the parsed/raw/ack tab `innerHTML` mega-string concatenation (nested `msg.segments.map().join('')` × `seg.fields.map().join('')`) with real `document.createElement` builders that `replaceChildren` once. Opening a message with many segments/fields no longer pays for thousands of intermediate string allocations. Segment collapse is now a CSS class on `.segment-block` — the field table is rendered once and hidden via `.segment-block.collapsed .field-table { display: none }`, so expanding/collapsing never rebuilds the DOM. JSON tab caches the `JSON.stringify` output in a module-scoped `WeakMap` keyed on the message object (no mutation of the data model) and invalidates the entry when tags/bookmark change.
 - **Performance — store eviction in O(n)** — rewrote the eviction loop in `MessageStore::insert`. The previous code collected indices and called `VecDeque::remove(i)` per candidate, which is O(n) each — combined with the candidate loop this was O(n²) and kept the write lock held during the whole pass, blocking MLLP ingestion and UI reads. The new loop pops candidates from the front, sets bookmarked ones aside, evicts the rest, and pushes the bookmarks back. Single linear pass, no per-element shift. Added test `test_eviction_skips_scattered_bookmarks` covering scattered bookmarks among eviction candidates.
@@ -26,6 +27,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 | Commit | Description |
 |--------|-------------|
+| [`fb41636`](https://github.com/Pappet/harux/commit/fb41636315214e0195ef1030ae4eb20e454ad35d) | `refactor:` split parse_message into composable passes |
 | [`8ed739b`](https://github.com/Pappet/harux/commit/8ed739bbf9ffff46c1a058043eaed547a7e2dd7b) | `perf:` move eviction to background task (#130) |
 
 #### 2026-05-14

--- a/src/hl7/parser.rs
+++ b/src/hl7/parser.rs
@@ -362,6 +362,10 @@ mod tests {
         let msg = enrich_msh(msg, delimiters);
         let msg = enrich_pid(msg, delimiters);
         let warnings = validate(&msg);
-        assert!(warnings.is_empty(), "Expected no warnings for valid ADT, got: {:?}", warnings);
+        assert!(
+            warnings.is_empty(),
+            "Expected no warnings for valid ADT, got: {:?}",
+            warnings
+        );
     }
 }

--- a/src/hl7/parser.rs
+++ b/src/hl7/parser.rs
@@ -3,6 +3,18 @@ use super::types::*;
 /// Parse a raw HL7 v2.x message string into a structured Hl7Message.
 /// Handles standard and custom delimiters from MSH segment.
 pub fn parse_message(raw: &str, source_addr: &str) -> Result<Hl7Message, String> {
+    let (msg, delimiters) = parse_structure(raw, source_addr)?;
+    let msg = enrich_msh(msg, delimiters);
+    let msg = enrich_pid(msg, delimiters);
+    let msg = inject_descriptions(msg);
+    let msg = annotate_message_type(msg);
+    let (mut msg, warnings) = validate(msg);
+    msg.validation_warnings = warnings;
+
+    Ok(msg)
+}
+
+fn parse_structure(raw: &str, source_addr: &str) -> Result<(Hl7Message, Delimiters), String> {
     let raw = raw.trim();
     if raw.is_empty() {
         return Err("Empty message".into());
@@ -26,6 +38,10 @@ pub fn parse_message(raw: &str, source_addr: &str) -> Result<Hl7Message, String>
         msg.segments.push(segment);
     }
 
+    Ok((msg, delimiters))
+}
+
+fn enrich_msh(mut msg: Hl7Message, delimiters: Delimiters) -> Hl7Message {
     // Extract key fields from MSH
     if let Some(msh) = msg.segments.first() {
         // Use HL7-standard field numbers (1-based): MSH-1=separator, MSH-2=encoding chars, etc.
@@ -49,7 +65,10 @@ pub fn parse_message(raw: &str, source_addr: &str) -> Result<Hl7Message, String>
         msg.message_control_id = get_field_value(msh, 10);
         msg.version = get_field_value(msh, 12);
     }
+    msg
+}
 
+fn enrich_pid(mut msg: Hl7Message, delimiters: Delimiters) -> Hl7Message {
     // Extract patient info from PID segment
     if let Some(pid) = msg.segments.iter().find(|s| s.name == "PID") {
         // PID-3: Patient ID
@@ -78,7 +97,10 @@ pub fn parse_message(raw: &str, source_addr: &str) -> Result<Hl7Message, String>
             }
         }
     }
+    msg
+}
 
+fn inject_descriptions(mut msg: Hl7Message) -> Hl7Message {
     // Second pass: inject field descriptions from the embedded dictionary
     let version = if msg.version.is_empty() {
         "2.5.1"
@@ -86,7 +108,10 @@ pub fn parse_message(raw: &str, source_addr: &str) -> Result<Hl7Message, String>
         &msg.version
     };
     crate::dictionary::inject_descriptions(&mut msg.segments, version);
+    msg
+}
 
+fn annotate_message_type(mut msg: Hl7Message) -> Hl7Message {
     // Third pass: look up message type description and typical segments
     if let Some(info) = super::message_types::get_message_type_info(&msg.message_type) {
         msg.message_type_description = Some(info.description.to_string());
@@ -103,11 +128,13 @@ pub fn parse_message(raw: &str, source_addr: &str) -> Result<Hl7Message, String>
             })
             .collect();
     }
+    msg
+}
 
+fn validate(msg: Hl7Message) -> (Hl7Message, Vec<crate::validation::ValidationWarning>) {
     // Fourth pass: validate required segments and fields
-    msg.validation_warnings = crate::validation::validate_message(&msg);
-
-    Ok(msg)
+    let warnings = crate::validation::validate_message(&msg);
+    (msg, warnings)
 }
 
 fn parse_delimiters(raw: &str) -> Result<Delimiters, String> {
@@ -276,5 +303,65 @@ mod tests {
             res.unwrap_err(),
             "MSH segment too short to extract delimiters"
         );
+    }
+
+    #[test]
+    fn test_parse_structure() {
+        let (msg, _) = parse_structure(SAMPLE_ADT, "127.0.0.1:9999").unwrap();
+        assert_eq!(msg.segments.len(), 3);
+        assert_eq!(msg.segments[0].name, "MSH");
+        assert_eq!(msg.segments[1].name, "PID");
+        assert_eq!(msg.segments[2].name, "PV1");
+        assert_eq!(msg.message_type, ""); // Not enriched yet
+    }
+
+    #[test]
+    fn test_enrich_msh() {
+        let (msg, delimiters) = parse_structure(SAMPLE_ADT, "127.0.0.1:9999").unwrap();
+        let msg = enrich_msh(msg, delimiters);
+        assert_eq!(msg.message_type, "ADT^A01");
+        assert_eq!(msg.trigger_event, "A01");
+        assert_eq!(msg.sending_application, "SENDING_APP");
+        assert_eq!(msg.sending_facility, "SENDING_FAC");
+        assert_eq!(msg.message_control_id, "MSG00001");
+        assert_eq!(msg.version, "2.5");
+    }
+
+    #[test]
+    fn test_enrich_pid() {
+        let (msg, delimiters) = parse_structure(SAMPLE_ADT, "127.0.0.1:9999").unwrap();
+        let msg = enrich_pid(msg, delimiters);
+        assert_eq!(msg.patient_id, Some("12345".into()));
+        assert_eq!(msg.patient_name, Some("Smith, John".into()));
+    }
+
+    #[test]
+    fn test_inject_descriptions() {
+        let (msg, _) = parse_structure(SAMPLE_ADT, "127.0.0.1:9999").unwrap();
+        let mut msg = msg;
+        msg.version = "2.5".to_string(); // Need version for description lookup
+        let msg = inject_descriptions(msg);
+        // We know MSH-9 should get a description injected if dictionary works
+        let msh = &msg.segments[0];
+        let field9 = msh.fields.iter().find(|f| f.index == 9).unwrap();
+        assert!(field9.description.is_some());
+    }
+
+    #[test]
+    fn test_annotate_message_type() {
+        let (msg, delimiters) = parse_structure(SAMPLE_ADT, "127.0.0.1:9999").unwrap();
+        let msg = enrich_msh(msg, delimiters);
+        let msg = annotate_message_type(msg);
+        assert!(msg.message_type_description.is_some());
+        assert!(!msg.typical_segments.is_empty());
+    }
+
+    #[test]
+    fn test_validate() {
+        let (msg, _) = parse_structure(SAMPLE_ADT, "127.0.0.1:9999").unwrap();
+        let (_, warnings) = validate(msg);
+        // Without full enrichment, the validation should probably return warnings
+        // but we just test that it runs without panicking.
+        assert!(warnings.len() >= 0); // valid type, just check it returns
     }
 }

--- a/src/hl7/parser.rs
+++ b/src/hl7/parser.rs
@@ -8,8 +8,8 @@ pub fn parse_message(raw: &str, source_addr: &str) -> Result<Hl7Message, String>
     let msg = enrich_pid(msg, delimiters);
     let msg = inject_descriptions(msg);
     let msg = annotate_message_type(msg);
-    let (mut msg, warnings) = validate(msg);
-    msg.validation_warnings = warnings;
+    let mut msg = msg;
+    msg.validation_warnings = validate(&msg);
 
     Ok(msg)
 }
@@ -131,10 +131,9 @@ fn annotate_message_type(mut msg: Hl7Message) -> Hl7Message {
     msg
 }
 
-fn validate(msg: Hl7Message) -> (Hl7Message, Vec<crate::validation::ValidationWarning>) {
+fn validate(msg: &Hl7Message) -> Vec<crate::validation::ValidationWarning> {
     // Fourth pass: validate required segments and fields
-    let warnings = crate::validation::validate_message(&msg);
-    (msg, warnings)
+    crate::validation::validate_message(msg)
 }
 
 fn parse_delimiters(raw: &str) -> Result<Delimiters, String> {
@@ -358,10 +357,11 @@ mod tests {
 
     #[test]
     fn test_validate() {
-        let (msg, _) = parse_structure(SAMPLE_ADT, "127.0.0.1:9999").unwrap();
-        let (_, warnings) = validate(msg);
-        // Without full enrichment, the validation should probably return warnings
-        // but we just test that it runs without panicking.
-        assert!(warnings.len() >= 0); // valid type, just check it returns
+        let valid_adt = "MSH|^~\\&|APP|FAC|APP|FAC|2024||ADT^A01|MSG001|P|2.5\rEVN||2024\rPID|||12345||Smith^John||1980|M\rPV1||I";
+        let (msg, delimiters) = parse_structure(valid_adt, "127.0.0.1:9999").unwrap();
+        let msg = enrich_msh(msg, delimiters);
+        let msg = enrich_pid(msg, delimiters);
+        let warnings = validate(&msg);
+        assert!(warnings.is_empty(), "Expected no warnings for valid ADT, got: {:?}", warnings);
     }
 }


### PR DESCRIPTION
Closes #122

### Fix Details
The `parse_message` function in `src/hl7/parser.rs` was a monolithic 110-line function with too many responsibilities, making it difficult to maintain and test. This PR resolves the tech debt by breaking it down into distinct, composable passes:
- `parse_structure`
- `enrich_msh`
- `enrich_pid`
- `inject_descriptions`
- `annotate_message_type`
- `validate`

Each pass now has independent unit test coverage. This change is fully backwards compatible and all existing unit tests, including the new integration tests, pass successfully.