### PR TITLE
fix(export): include original HL7 payload in Export download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **Keyboard accessibility for source chips** — added `tabindex="0"`, `role="button"`, and Enter/Space keyboard activation for source chips in the message list header, allowing filter toggling via keyboard navigation.
 
 ### Fixed
+- **Export now delivers the original HL7 payload** — the Export button previously called `/api/messages?limit=100000`, which returns `Hl7MessageSummary` (metadata + ACK only — no `raw`, no `segments`). The downloaded JSON therefore carried just the outbound ACK and patient summary; the original inbound HL7 message was missing, making the export useless for replay or external analysis. Added a new `GET /api/export` endpoint that streams every stored message's raw payload back as one MLLP-framed `.hl7` file (oldest first, wrapped in VT … FS CR), and switched the frontend `exportMessages()` to download it as `harux-export-<timestamp>.hl7`. The resulting file is directly replayable into any MLLP listener (`nc host port < harux-export.hl7`). New `MessageStore::list_all_raw` provides the snapshot in insertion order.
 - **File-logger setup failure no longer panics** — a missing or unwritable log directory previously called `panic!` before tracing was initialized, causing the server to die on startup on Windows Server when the log path was misconfigured. Now falls back to stdout with a `WARN` line printed to stderr via `eprintln!` (tracing is not yet available at that point). (#113)
 - **MLLP read-loop distinguishes EOF, timeout, and socket errors** — the three cases were collapsed into one `Ok(Ok(0)) | Err(_)` arm, so real socket errors were logged as "connection closed" and a timeout with partial data produced no log at all. Each case now has its own arm: clean EOF → `debug!`, read timeout → `debug!`, socket error → `warn!` with the error detail. (#152)
 
@@ -33,6 +34,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 | Commit | Description |
 |--------|-------------|
+| [`abe3d66`](https://github.com/Pappet/harux/commit/abe3d66aa47d2277f4f786befe776fc10f6f2786) | `fix(export):` include original HL7 payload in Export download |
 | [`599b45a`](https://github.com/Pappet/harux/commit/599b45a76eebd19a0434d227ee2a1888cf57d6ed) | `fix(ui):` tone down Raw-tab separators to muted grey |
 | [`dbf409c`](https://github.com/Pappet/harux/commit/dbf409cbe160aa6a6d1b5a98d91b601f25cbb0ec) | `fix(ui):` skip delimiter highlighting when MSH is absent |
 | [`2217b44`](https://github.com/Pappet/harux/commit/2217b44b4b35df73391c176bcb1d791a725c84bd) | `feat(ui):` colourise HL7 delimiters and JSON tokens in detail tabs |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 | Commit | Description |
 |--------|-------------|
-| [`abe3d66`](https://github.com/Pappet/harux/commit/abe3d66aa47d2277f4f786befe776fc10f6f2786) | `fix(export):` include original HL7 payload in Export download |
+| [`f162e12`](https://github.com/Pappet/harux/commit/f162e12b3741a65ae1794f813829ef9e7b76ae5c) | `fix(export):` include original HL7 payload in Export download |
 | [`599b45a`](https://github.com/Pappet/harux/commit/599b45a76eebd19a0434d227ee2a1888cf57d6ed) | `fix(ui):` tone down Raw-tab separators to muted grey |
 | [`dbf409c`](https://github.com/Pappet/harux/commit/dbf409cbe160aa6a6d1b5a98d91b601f25cbb0ec) | `fix(ui):` skip delimiter highlighting when MSH is absent |
 | [`2217b44`](https://github.com/Pappet/harux/commit/2217b44b4b35df73391c176bcb1d791a725c84bd) | `feat(ui):` colourise HL7 delimiters and JSON tokens in detail tabs |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Harux is an MLLP server with a real-time web UI for inspecting HL7 v2.x messages
 - `GET /api/search?q=&limit=` — Search messages (client-side in UI, server-side via this endpoint)
 - `GET /api/stats` — Server statistics
 - `POST /api/clear` — Clear all messages
+- `GET /api/export` — Download every stored message as one MLLP-framed `.hl7` file (raw payloads, oldest first, directly replayable)
 - `WS /ws` — Real-time updates ("init", "new_message", "lagged" events)
 
 ### Frontend (`static/`)

--- a/src/store.rs
+++ b/src/store.rs
@@ -123,6 +123,18 @@ impl MessageStore {
         self.inner.read().await.messages.get(id).cloned()
     }
 
+    /// Snapshot of every stored message's raw HL7 payload, in insertion order
+    /// (oldest first — so replaying the result preserves the original sequence).
+    pub async fn list_all_raw(&self) -> Vec<String> {
+        let inner = self.inner.read().await;
+        inner
+            .order
+            .iter()
+            .filter_map(|id| inner.messages.get(id))
+            .map(|arc| arc.raw.clone())
+            .collect()
+    }
+
     /// Search messages by filter text (matches message type, patient name, facility, etc.)
     pub async fn search(&self, query: &str, limit: usize) -> Vec<Hl7MessageSummary> {
         let query_lower = query.to_lowercase();

--- a/src/web.rs
+++ b/src/web.rs
@@ -39,6 +39,7 @@ pub fn create_router(state: AppState) -> Router {
             axum::routing::post(toggle_bookmark),
         )
         .route("/api/clear", axum::routing::post(clear_messages))
+        .route("/api/export", get(export_raw_hl7))
         // WebSocket
         .route("/ws", get(ws_handler))
         // Static files (SPA)
@@ -106,6 +107,40 @@ async fn clear_messages(State(state): State<AppState>) -> impl IntoResponse {
     state.store.clear().await;
     state.stats.reset_message_counters();
     Json(serde_json::json!({"status": "cleared"}))
+}
+
+/// Stream every stored message as a single MLLP-framed payload.
+///
+/// Each message is wrapped in the original MLLP envelope (VT … FS CR), so the
+/// resulting `.hl7` file can be replayed straight into an MLLP listener (e.g.
+/// `nc host port < harux-export.hl7`) and the framing also serves as an
+/// unambiguous message separator when opening the file in tools that
+/// understand HL7.
+async fn export_raw_hl7(State(state): State<AppState>) -> impl IntoResponse {
+    const MLLP_START: u8 = 0x0B;
+    const MLLP_END_1: u8 = 0x1C;
+    const MLLP_END_2: u8 = 0x0D;
+
+    let raws = state.store.list_all_raw().await;
+    let total: usize = raws.iter().map(|r| r.len() + 3).sum();
+    let mut body = Vec::with_capacity(total);
+    for raw in raws {
+        body.push(MLLP_START);
+        body.extend_from_slice(raw.as_bytes());
+        body.push(MLLP_END_1);
+        body.push(MLLP_END_2);
+    }
+
+    (
+        [
+            (axum::http::header::CONTENT_TYPE, "application/octet-stream"),
+            (
+                axum::http::header::CONTENT_DISPOSITION,
+                "attachment; filename=\"harux-export.hl7\"",
+            ),
+        ],
+        body,
+    )
 }
 
 #[derive(Deserialize)]

--- a/static/app.js
+++ b/static/app.js
@@ -86,14 +86,13 @@ function toggleValidationFilter() {
 // --- Bulk actions ---
 async function exportMessages() {
     try {
-        const resp = await fetch('/api/messages?limit=100000');
+        const resp = await fetch('/api/export');
         if (!resp.ok) throw new Error(`Server error: ${resp.status}`);
-        const data = await resp.json();
-        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        const blob = await resp.blob();
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = `harux-export-${new Date().toISOString().slice(0, 19)}.json`;
+        a.download = `harux-export-${new Date().toISOString().slice(0, 19)}.hl7`;
         a.click();
         URL.revokeObjectURL(url);
     } catch (e) {


### PR DESCRIPTION
## Summary

The **Export** button was effectively useless: it called `/api/messages?limit=100000`, which returns `Hl7MessageSummary` (metadata + outbound ACK only — no `raw`, no `segments`). The user observed correctly that the downloaded JSON contained the ACK we sent back, but **not** the original inbound HL7 message — making the export impossible to re-import or replay.

### Fix Details

**Why this happened**

`Hl7MessageSummary` (`src/hl7/types.rs:113`) is the lightweight shape used for the message list; it deliberately omits `raw` and `segments` to keep `/api/messages` responses small. The Export handler reused that endpoint, so the heavy fields were never sent.

**Architectural change**

Rather than thicken the summary or fetch each full message one-by-one, the cleanest path is a dedicated bulk-export endpoint that streams the **raw HL7 payload** of every stored message — which is the only artifact a downstream tool actually needs to replay.

- **`MessageStore::list_all_raw`** (`src/store.rs`) — new snapshot method that returns every message's `raw` string in **insertion order** (oldest first), so replaying the file preserves the original sequence. Uses the existing `Arc<Hl7Message>` storage; only the raw `String` is cloned.
- **`GET /api/export`** (`src/web.rs`) — new handler that builds one **MLLP-framed** byte stream (`VT … FS CR` per message) and returns it with `Content-Type: application/octet-stream` + `Content-Disposition: attachment; filename="harux-export.hl7"`. The MLLP envelope acts as an unambiguous separator and makes the file directly replayable: `nc host port < harux-export.hl7`.
- **`exportMessages()`** (`static/app.js`) — switched from `fetch('/api/messages?limit=100000') → JSON.stringify` to `fetch('/api/export').blob()` and downloads `harux-export-<timestamp>.hl7`.
- **Docs** — added the new route to the API list in `CLAUDE.md`.

**Verification**

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ (11 tests pass)
- The MLLP framing constants (`0x0B`, `0x1C`, `0x0D`) match those in `src/mllp.rs`.

### Trade-offs considered

Discussed with the user; chose **raw HL7 only** over a full structured JSON export. Trade-off: loses tags / bookmarks / validation warnings / source addresses in the download, but maximises replay value — which was the user's actual complaint. A structured JSON export can be added later under a separate route if needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_0192GS4k8HRi2CpyVhg2PzrK)_