### PR TITLE
fix: MSH-9.3 capture, shared field lookup, search perf, drain Notify, web panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 
 | Commit | Description |
 |--------|-------------|
-| [`placeholder`](https://github.com/Pappet/harux/commit/placeholder) | `fix(store):` handle non-ASCII needles in contains_ignore_ascii_case (#133) |
+| [`1b9fb8f`](https://github.com/Pappet/harux/commit/1b9fb8f) | `fix(store):` handle non-ASCII needles in contains_ignore_ascii_case (#133) |
 
 #### 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 ### Fixed
 - **Web server transient error no longer panics** — `axum::serve(...).expect("Web server failed")` inside a spawned task would panic the task on any transient I/O error. The `.expect()` is replaced with `if let Err(e) = ... { warn!(...) }` so the task exits cleanly and `tokio::select!` in `main` triggers the graceful shutdown path. (#114)
 - **Busy-poll drain loop replaced with event-driven `Notify`** — the graceful shutdown path spun in a 100 ms sleep loop checking `active_connections`. Added `drain_notify: Arc<Notify>` to `MllpStats`; each connection handler calls `notify_one()` when it decrements the counter to zero. `main` now uses `tokio::time::timeout(shutdown_timeout, drain_notify.notified())` — zero CPU during the drain wait, exact wake-up on last connection close. (#115)
-- **`MessageStore::search` — zero heap allocation per message per query** — the previous implementation called `.to_lowercase()` on six fields of every stored message on each search request (up to 60 000 short-lived `String`s for a full 10 000-message store). Replaced with `contains_ignore_ascii_case`, a window-scan that calls `eq_ignore_ascii_case` byte-by-byte with no allocation. HL7 data is ASCII/Latin-1, so this is both correct and faster. (#133)
+- **`MessageStore::search` — zero heap allocation per message per query** — the previous implementation called `.to_lowercase()` on six fields of every stored message on each search request (up to 60 000 short-lived `String`s for a full 10 000-message store). Replaced with `contains_ignore_ascii_case`, a window-scan that calls `eq_ignore_ascii_case` byte-by-byte with no allocation for ASCII needles. For non-ASCII needles the function falls back to `to_lowercase().contains()` so multi-byte code-point boundaries are never sliced. HL7 data is almost always ASCII, so the fast path is taken in practice. (#133)
 
 ### Changed
 - **`SegmentDef::field_by_seq` — single shared lookup helper** — the O(1)-fast-path + O(N)-fallback field lookup pattern was duplicated verbatim in `dictionary.rs` (`get_field_description` and `inject_descriptions`) and `validation.rs` (`validate_data_types`). Extracted to `SegmentDef::field_by_seq(seq: usize) -> Option<&FieldDef>`. All three call sites replaced with a single method call. (#128)
@@ -56,6 +56,12 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **Performance — incremental message-list rendering + source-counts cache** — `flushAndRender` now prepends only new rows to the DOM via `prependMessagesToList` when no client-side filter is active, instead of removing every `.message-row` / `.group-header` and rebuilding from scratch each 250 ms flush. Selection changes call `updateRowSelection` (class toggle only), and tag/bookmark updates call `patchRow` to mutate just the affected row (the previous code re-rendered the entire list per WebSocket tag/bookmark event). Source counts are maintained in a `sourceCounts: Map` updated incrementally in `addMessage` and recomputed only when labelling changes (`toggleColorByPort`) or the buffer is replaced (`loadMessages`, `clearMessages`, server `cleared`), so `renderSourceLegend` no longer iterates `messages[]` on every flush. Group headers carry `data-bucket` so the prepend path knows when to emit a new time-bucket header.
 
 ### Commit History (chronological)
+
+#### 2026-05-16
+
+| Commit | Description |
+|--------|-------------|
+| [`placeholder`](https://github.com/Pappet/harux/commit/placeholder) | `fix(store):` handle non-ASCII needles in contains_ignore_ascii_case (#133) |
 
 #### 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 ## [Unreleased]
 
 ### Added
+- **`Hl7Message::message_structure`** — captures the MSH-9.3 message structure identifier (e.g. `"ADT_A01"`, `"ORU_R01"`) into a new `Option<String>` field on `Hl7Message`. Falls back to `None` for older HL7 v2.3 senders that omit the third component. This field is the foundation for per-structure validation rules in Milestone 3. (#123)
+
+### Fixed
+- **Web server transient error no longer panics** — `axum::serve(...).expect("Web server failed")` inside a spawned task would panic the task on any transient I/O error. The `.expect()` is replaced with `if let Err(e) = ... { warn!(...) }` so the task exits cleanly and `tokio::select!` in `main` triggers the graceful shutdown path. (#114)
+- **Busy-poll drain loop replaced with event-driven `Notify`** — the graceful shutdown path spun in a 100 ms sleep loop checking `active_connections`. Added `drain_notify: Arc<Notify>` to `MllpStats`; each connection handler calls `notify_one()` when it decrements the counter to zero. `main` now uses `tokio::time::timeout(shutdown_timeout, drain_notify.notified())` — zero CPU during the drain wait, exact wake-up on last connection close. (#115)
+- **`MessageStore::search` — zero heap allocation per message per query** — the previous implementation called `.to_lowercase()` on six fields of every stored message on each search request (up to 60 000 short-lived `String`s for a full 10 000-message store). Replaced with `contains_ignore_ascii_case`, a window-scan that calls `eq_ignore_ascii_case` byte-by-byte with no allocation. HL7 data is ASCII/Latin-1, so this is both correct and faster. (#133)
+
+### Changed
+- **`SegmentDef::field_by_seq` — single shared lookup helper** — the O(1)-fast-path + O(N)-fallback field lookup pattern was duplicated verbatim in `dictionary.rs` (`get_field_description` and `inject_descriptions`) and `validation.rs` (`validate_data_types`). Extracted to `SegmentDef::field_by_seq(seq: usize) -> Option<&FieldDef>`. All three call sites replaced with a single method call. (#128)
+
 - **Syntax highlighting in Raw / ACK / JSON tabs** — segment names keep their accent colour and now sit alongside coloured HL7 delimiters. The 5 delimiters are auto-detected from MSH-1 / MSH-2, so non-standard separator characters are highlighted just as well as the spec defaults. When MSH is missing entirely (malformed payload) no delimiter colouring is applied — we don't pretend to know separators we never saw. The JSON tab now distinguishes keys, strings, numbers, booleans and `null` with dedicated colours; pretty-print whitespace is preserved and arbitrary string values are still safely HTML-escaped.
 - **Keyboard accessibility for custom elements** — added `tabindex`, `role="button"`, and Enter/Space keyboard activation for segment headers, copy buttons, field value cells, and tagging elements.
 - **Keyboard accessibility for source chips** — added `tabindex="0"`, `role="button"`, and Enter/Space keyboard activation for source chips in the message list header, allowing filter toggling via keyboard navigation.

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -15,6 +15,18 @@ pub struct SegmentDef {
     pub fields: Vec<FieldDef>,
 }
 
+impl SegmentDef {
+    /// Look up a field by its 1-based HL7 sequence number.
+    /// Uses an O(1) index fast-path first; falls back to a linear scan when the
+    /// dictionary fields are not perfectly sequential (sparse or non-standard segments).
+    pub fn field_by_seq(&self, seq: usize) -> Option<&FieldDef> {
+        self.fields
+            .get(seq.saturating_sub(1))
+            .filter(|f| f.seq == seq)
+            .or_else(|| self.fields.iter().find(|f| f.seq == seq))
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct VersionDef {
     /// Version string from the JSON file (e.g. `"2.5.1"`); reserved for future version-aware lookup.
@@ -39,23 +51,10 @@ pub fn get_field_description(segment: &str, field_seq: usize) -> Option<String> 
     // Currently fallback to v2.5.1 for all versions, could be extended later
     let dict = get_v251();
 
-    if let Some(seg_def) = dict.segments.get(segment) {
-        // Try O(1) fast-path first assuming perfect sequence, fallback to O(N) search.
-        let field_def = if field_seq > 0 {
-            seg_def.fields.get(field_seq - 1)
-        } else {
-            None
-        };
-
-        let field_def = field_def
-            .filter(|f| f.seq == field_seq)
-            .or_else(|| seg_def.fields.iter().find(|f| f.seq == field_seq));
-
-        if let Some(field_def) = field_def {
-            return Some(field_def.desc.clone());
-        }
-    }
-    None
+    dict.segments
+        .get(segment)
+        .and_then(|seg| seg.field_by_seq(field_seq))
+        .map(|f| f.desc.clone())
 }
 
 /// Return the description for a segment (e.g. "MSH" → "Message Header").
@@ -70,17 +69,7 @@ pub fn inject_descriptions(segments: &mut [crate::hl7::types::Hl7Segment]) {
         if let Some(seg_def) = dict.segments.get(&seg_name) {
             segment.description = Some(seg_def.desc.clone());
             for field in segment.fields.iter_mut() {
-                let field_def = if field.index > 0 {
-                    seg_def.fields.get(field.index - 1)
-                } else {
-                    None
-                };
-
-                let field_def = field_def
-                    .filter(|f| f.seq == field.index)
-                    .or_else(|| seg_def.fields.iter().find(|f| f.seq == field.index));
-
-                if let Some(field_def) = field_def {
+                if let Some(field_def) = seg_def.field_by_seq(field.index) {
                     field.description = Some(field_def.desc.clone());
                 }
             }

--- a/src/hl7/parser.rs
+++ b/src/hl7/parser.rs
@@ -57,6 +57,12 @@ fn enrich_msh(mut msg: Hl7Message, delimiters: Delimiters) -> Hl7Message {
             if let Some(c1) = type_components.next() {
                 msg.message_type = format!("{}^{}", c0, c1);
                 msg.trigger_event = c1.to_string();
+                // MSH-9.3: optional message structure identifier (e.g. "ADT_A01")
+                if let Some(c2) = type_components.next() {
+                    if !c2.is_empty() {
+                        msg.message_structure = Some(c2.to_string());
+                    }
+                }
             } else {
                 msg.message_type = c0.to_string();
             }

--- a/src/hl7/types.rs
+++ b/src/hl7/types.rs
@@ -56,6 +56,10 @@ pub struct Hl7Message {
     pub typical_segment_descriptions: HashMap<String, String>,
     /// Character set declared in MSH-18, e.g. `"UTF-8"` or `"8859/1"`; `None` if absent.
     pub charset: Option<String>,
+    /// MSH-9.3 message structure identifier, e.g. `"ADT_A01"` or `"ORU_R01"`.
+    /// Used by Milestone 3 validation to select the correct structure definition.
+    /// `None` when MSH-9 has fewer than three components (common in HL7 v2.3 senders).
+    pub message_structure: Option<String>,
 }
 
 /// One segment within an HL7 message (e.g. `MSH`, `PID`, `OBR`).
@@ -189,6 +193,7 @@ impl Hl7Message {
             typical_segments: Vec::new(),
             typical_segment_descriptions: HashMap::new(),
             charset: None,
+            message_structure: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,13 +100,15 @@ async fn main() -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(&web_addr).await?;
     let web_shutdown = shutdown_rx.clone();
     let web_handle = tokio::spawn(async move {
-        axum::serve(listener, app)
+        if let Err(e) = axum::serve(listener, app)
             .with_graceful_shutdown(async move {
                 let mut rx = web_shutdown;
                 let _ = rx.changed().await;
             })
             .await
-            .expect("Web server failed");
+        {
+            warn!("Web server error: {}", e);
+        }
     });
 
     // Wait for a shutdown signal or an unexpected server exit
@@ -124,29 +126,25 @@ async fn main() -> anyhow::Result<()> {
 
     let _ = shutdown_tx.send(true);
 
-    // Wait for active MLLP connections to drain
+    // Wait for active MLLP connections to drain (event-driven, no polling).
     let shutdown_timeout = std::time::Duration::from_secs(config.server.shutdown_timeout_secs);
-    info!(
-        "Waiting up to {} seconds for MLLP connections to drain...",
-        config.server.shutdown_timeout_secs
-    );
-    let start = std::time::Instant::now();
-    loop {
-        let active = stats
-            .active_connections
-            .load(std::sync::atomic::Ordering::Relaxed);
-        if active == 0 {
-            info!("All MLLP connections drained");
-            break;
+    let active = stats
+        .active_connections
+        .load(std::sync::atomic::Ordering::Relaxed);
+    if active > 0 {
+        info!(
+            "Waiting up to {} seconds for {} MLLP connection(s) to drain...",
+            config.server.shutdown_timeout_secs, active
+        );
+        match tokio::time::timeout(shutdown_timeout, stats.drain_notify.notified()).await {
+            Ok(()) => info!("All MLLP connections drained"),
+            Err(_) => warn!(
+                "Shutdown timeout reached. Forcing exit with {} active connection(s)",
+                stats
+                    .active_connections
+                    .load(std::sync::atomic::Ordering::Relaxed)
+            ),
         }
-        if start.elapsed() >= shutdown_timeout {
-            warn!(
-                "Shutdown timeout reached. Forcing exit with {} active connections",
-                active
-            );
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 
     info!("Harux stopped.");

--- a/src/mllp.rs
+++ b/src/mllp.rs
@@ -24,6 +24,9 @@ pub struct MllpStats {
     pub parse_errors: Arc<AtomicU64>,
     pub active_connections: Arc<AtomicU64>,
     pub rejected_connections: Arc<AtomicU64>,
+    /// Notified whenever `active_connections` drops to zero, enabling a
+    /// non-polling graceful-shutdown wait in `main`.
+    pub drain_notify: Arc<tokio::sync::Notify>,
 }
 
 impl MllpStats {
@@ -49,6 +52,7 @@ impl Default for MllpStats {
             parse_errors: Arc::new(AtomicU64::new(0)),
             active_connections: Arc::new(AtomicU64::new(0)),
             rejected_connections: Arc::new(AtomicU64::new(0)),
+            drain_notify: Arc::new(tokio::sync::Notify::new()),
         }
     }
 }
@@ -95,9 +99,13 @@ pub async fn start_mllp_server(
                             if let Err(e) = handle_connection(socket, &peer, &store, &stats, &config, shutdown_clone).await {
                                 warn!("Connection error from {}: {}", peer, e);
                             }
-                            stats.active_connections.fetch_sub(1, Ordering::Relaxed);
+                            let remaining = stats.active_connections.fetch_sub(1, Ordering::Relaxed);
                             info!("MLLP connection closed: {}", peer);
                             drop(permit); // Release the semaphore permit
+                            if remaining == 1 {
+                                // We were the last connection; wake the drain waiter in main.
+                                stats.drain_notify.notify_one();
+                            }
                         });
                     }
                     Err(_) => {

--- a/src/store.rs
+++ b/src/store.rs
@@ -7,17 +7,26 @@ use tracing::{info, warn};
 
 const BROADCAST_CAPACITY: usize = 4096;
 
-/// Case-insensitive ASCII substring search with no heap allocation.
-/// HL7 fields are ASCII or Latin-1; Unicode multi-byte case folding is not needed here.
+/// Case-insensitive substring search.
+///
+/// Fast path: ASCII-only needle — byte-level windowed scan, zero allocation.
+/// ASCII code points are all single bytes, so windows of byte-length(needle)
+/// always align on character boundaries and `eq_ignore_ascii_case` is correct.
+///
+/// Slow path: non-ASCII needle (unusual for HL7 searches) — allocate and use
+/// Unicode-aware `to_lowercase` so multi-byte code points fold correctly.
 fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
     if needle.is_empty() {
         return true;
     }
-    let needle = needle.as_bytes();
-    haystack
-        .as_bytes()
-        .windows(needle.len())
-        .any(|w| w.eq_ignore_ascii_case(needle))
+    if needle.is_ascii() {
+        let needle = needle.as_bytes();
+        return haystack
+            .as_bytes()
+            .windows(needle.len())
+            .any(|w| w.eq_ignore_ascii_case(needle));
+    }
+    haystack.to_lowercase().contains(&needle.to_lowercase())
 }
 
 #[derive(Clone)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -7,6 +7,19 @@ use tracing::{info, warn};
 
 const BROADCAST_CAPACITY: usize = 4096;
 
+/// Case-insensitive ASCII substring search with no heap allocation.
+/// HL7 fields are ASCII or Latin-1; Unicode multi-byte case folding is not needed here.
+fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    let needle = needle.as_bytes();
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .any(|w| w.eq_ignore_ascii_case(needle))
+}
+
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum StoreEvent {
@@ -140,7 +153,6 @@ impl MessageStore {
 
     /// Search messages by filter text (matches message type, patient name, facility, etc.)
     pub async fn search(&self, query: &str, limit: usize) -> Vec<Hl7MessageSummary> {
-        let query_lower = query.to_lowercase();
         let inner = self.inner.read().await;
         inner
             .order
@@ -148,20 +160,16 @@ impl MessageStore {
             .rev()
             .filter_map(|id| inner.messages.get(id))
             .filter(|m| {
-                m.message_type.to_lowercase().contains(&query_lower)
-                    || m.sending_facility.to_lowercase().contains(&query_lower)
+                contains_ignore_ascii_case(&m.message_type, query)
+                    || contains_ignore_ascii_case(&m.sending_facility, query)
                     || m.patient_name
                         .as_deref()
-                        .unwrap_or("")
-                        .to_lowercase()
-                        .contains(&query_lower)
+                        .is_some_and(|n| contains_ignore_ascii_case(n, query))
                     || m.patient_id
                         .as_deref()
-                        .unwrap_or("")
-                        .to_lowercase()
-                        .contains(&query_lower)
-                    || m.message_control_id.to_lowercase().contains(&query_lower)
-                    || m.source_addr.contains(&query_lower)
+                        .is_some_and(|n| contains_ignore_ascii_case(n, query))
+                    || contains_ignore_ascii_case(&m.message_control_id, query)
+                    || contains_ignore_ascii_case(&m.source_addr, query)
             })
             .take(limit)
             .map(|arc| Hl7MessageSummary::from(arc.as_ref()))

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -353,16 +353,7 @@ fn validate_data_types(msg: &Hl7Message, warnings: &mut Vec<ValidationWarning>) 
             if field.value.is_empty() {
                 continue; // empty values are caught by MISSING_FIELD rules
             }
-            let field_def = if field.index > 0 {
-                seg_def.fields.get(field.index - 1)
-            } else {
-                None
-            };
-
-            let Some(field_def) = field_def
-                .filter(|f| f.seq == field.index)
-                .or_else(|| seg_def.fields.iter().find(|f| f.seq == field.index))
-            else {
+            let Some(field_def) = seg_def.field_by_seq(field.index) else {
                 continue;
             };
             // Use only the first component — composite values include sub-component


### PR DESCRIPTION
## Summary

Five targeted fixes across HL7 parsing, store search, and server reliability. Each issue is a self-contained change; no cross-domain coupling.

| Issue | Change |
|-------|--------|
| #123 (P2) | Add `Hl7Message::message_structure` populated from MSH-9.3 |
| #128 (P7) | Extract `SegmentDef::field_by_seq` — remove duplicated lookup pattern from 3 files |
| #133 (S4) | Replace 6× `to_lowercase()` per search with zero-alloc `contains_ignore_ascii_case` |
| #114 (B2) | Remove `.expect()` from web server task; propagate errors via `warn!` |
| #115 (B3) | Replace 100 ms busy-poll drain loop with `drain_notify: Arc<Notify>` on `MllpStats` |

## Fix Details

**P2 / #123 — `message_structure`**
`enrich_msh` parsed MSH-9 into two components (code + trigger event) and discarded the third: `MSG_STRUCTURE` (e.g. `"ADT_A01"`). This third component is the canonical identifier for Milestone 3 per-structure validation rules. Added `pub message_structure: Option<String>` to `Hl7Message`; populated from `type_components.next()` inside `enrich_msh`. Gracefully yields `None` when MSH-9 has fewer than three components (common in v2.3 senders).

**P7 / #128 — `SegmentDef::field_by_seq`**
The "O(1) fast-path, O(N) fallback" field-by-sequence-number lookup was duplicated verbatim in `dictionary.rs` (`get_field_description` and `inject_descriptions`) and `validation.rs` (`validate_data_types`). Extracted to `impl SegmentDef { pub fn field_by_seq(&self, seq: usize) -> Option<&FieldDef> }`. All three call sites now use the method; the duplicated 8-line blocks are gone.

**S4 / #133 — Zero-alloc search**
`MessageStore::search` previously called `.to_lowercase()` on six fields of every stored message per query — up to 60 000 short-lived `String` allocations for a 10 000-message store, all under the read lock. Replaced with `contains_ignore_ascii_case(haystack, needle)`: a `windows(needle.len()).any(|w| w.eq_ignore_ascii_case(needle))` scan. No heap allocation per message, O(n·m) scan in the worst case, correct for HL7's ASCII/Latin-1 character set.

**B2 / #114 — Web server no-panic**
`axum::serve(...).expect("Web server failed")` inside a `tokio::spawn` task would panic the task on any transient I/O error. Tokio catches task panics, so the `JoinHandle` completes with `Err(JoinError::Panic)`, and the `tokio::select!` arm in `main` already triggers graceful shutdown. However the panic still clutters logs and defeats tracing. Changed to `if let Err(e) = ... { warn!(...) }` — the task exits cleanly and the select arm sees a normal completion.

**B3 / #115 — Event-driven drain wait**
The graceful shutdown path spun in a 100 ms sleep loop checking `stats.active_connections` until zero or timeout. Added `drain_notify: Arc<tokio::sync::Notify>` to `MllpStats`. Each connection handler calls `drain_notify.notify_one()` immediately after `fetch_sub(1, Relaxed)` if the result was 1 (i.e., the connection was the last one). `main` now uses `tokio::time::timeout(shutdown_timeout, stats.drain_notify.notified())` — zero CPU during the drain wait, exact wake-up.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All 55 unit + 10 fixture + 1 benchmark tests pass
- [x] CI green

Closes #114
Closes #115
Closes #123
Closes #128
Closes #133

https://claude.ai/code/session_01SWqixCwoVwpV2tSgzZbdMk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWqixCwoVwpV2tSgzZbdMk)_