### PR TITLE
chore(deps): upgrade axum 0.7→0.8 and tower-http 0.5→0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 | Commit | Description |
 |--------|-------------|
 | [`1b9fb8f`](https://github.com/Pappet/harux/commit/1b9fb8f) | `fix(store):` handle non-ASCII needles in contains_ignore_ascii_case (#133) |
-| [`PLACEHOLDER`](https://github.com/Pappet/harux/commit/PLACEHOLDER) | `chore(deps):` upgrade axum 0.7→0.8, tower-http 0.5→0.6 (#147) |
+| [`16ece72`](https://github.com/Pappet/harux/commit/16ece72) | `chore(deps):` upgrade axum 0.7→0.8, tower-http 0.5→0.6 (#147) |
 
 #### 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **MLLP read-loop distinguishes EOF, timeout, and socket errors** — the three cases were collapsed into one `Ok(Ok(0)) | Err(_)` arm, so real socket errors were logged as "connection closed" and a timeout with partial data produced no log at all. Each case now has its own arm: clean EOF → `debug!`, read timeout → `debug!`, socket error → `warn!` with the error detail. (#152)
 
 ### Changed
+- **Dependency upgrade — axum 0.7 → 0.8, tower-http 0.5 → 0.6** — updated to the latest axum major version. Route path syntax updated from `/:param` to `/{param}` per axum 0.8 convention. `Message::Text` now wraps `Utf8Bytes` instead of `String`; three call sites updated with `.into()`. (#147)
 - **Tech debt — `dictionary.rs` allow-attr removal + dead version parameter** — removed the file-level `#![allow(dead_code)]` and `#![allow(unused_variables)]` suppressors. The unused `version` parameter was eliminated from `get_field_description` and `inject_descriptions`; all call sites updated. Residually-unused items (`VersionDef::version` field needed for JSON deserialization, `get_field_description` as future public API) carry targeted `#[allow(dead_code)]` with explanatory comments. (#127)
 - **Refactor — `validation.rs` deduplication** — the three near-identical `warnings.push(...)` blocks for OBX-2, OBX-3, and OBX-11 now use the existing `warn_missing_field` helper. The inline ADT PV1-required event list is extracted to a `PV1_REQUIRED_ADT_EVENTS` module-level constant. (#124, #125)
 - **Refactor — NACK builder in `parser.rs`** — added `build_nack(reason)` alongside `build_ack` so both ACK and NACK responses share the same code path. The hardcoded MSH string literal in `mllp.rs` is replaced with a call to `build_nack`. (#117)
@@ -63,6 +64,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 | Commit | Description |
 |--------|-------------|
 | [`1b9fb8f`](https://github.com/Pappet/harux/commit/1b9fb8f) | `fix(store):` handle non-ASCII needles in contains_ignore_ascii_case (#133) |
+| [`PLACEHOLDER`](https://github.com/Pappet/harux/commit/PLACEHOLDER) | `chore(deps):` upgrade axum 0.7→0.8, tower-http 0.5→0.6 (#147) |
 
 #### 2026-05-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,17 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,14 +40,14 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "base64",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -66,13 +55,12 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -81,55 +69,6 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
-dependencies = [
- "axum-core 0.5.6",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit 0.8.4",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -151,6 +90,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -179,12 +119,6 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -385,13 +319,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -412,7 +347,7 @@ name = "harux"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "axum 0.7.9",
+ "axum",
  "chrono",
  "encoding_rs",
  "mime_guess",
@@ -629,12 +564,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -771,20 +700,19 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -792,11 +720,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -822,7 +750,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
 dependencies = [
- "axum 0.8.8",
+ "axum",
  "rust-embed-impl",
  "rust-embed-utils",
  "walkdir",
@@ -1041,31 +969,11 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1148,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -1230,12 +1138,13 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1250,7 +1159,6 @@ dependencies = [
  "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1284,7 +1192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tracing-subscriber",
 ]
@@ -1341,11 +1249,10 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
@@ -1353,7 +1260,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ all = "warn"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "time", "macros", "io-util", "signal"] }
 
 # Web framework + WebSocket
-axum = { version = "0.7", features = ["ws"] }
-tower-http = { version = "0.5", features = ["cors", "fs"] }
+axum = { version = "0.8", features = ["ws"] }
+tower-http = { version = "0.6", features = ["cors", "fs"] }
 
 # Serialization
 serde = { version = "1", features = ["derive", "rc"] }

--- a/src/web.rs
+++ b/src/web.rs
@@ -56,16 +56,16 @@ pub fn create_router(state: AppState) -> Router {
     Router::new()
         // API routes
         .route("/api/messages", get(list_messages))
-        .route("/api/messages/:id", get(get_message))
+        .route("/api/messages/{id}", get(get_message))
         .route("/api/search", get(search_messages))
         .route("/api/stats", get(get_stats))
-        .route("/api/messages/:id/tags", axum::routing::post(add_tag))
+        .route("/api/messages/{id}/tags", axum::routing::post(add_tag))
         .route(
-            "/api/messages/:id/tags/:tag",
+            "/api/messages/{id}/tags/{tag}",
             axum::routing::delete(remove_tag),
         )
         .route(
-            "/api/messages/:id/bookmark",
+            "/api/messages/{id}/bookmark",
             axum::routing::post(toggle_bookmark),
         )
         .route("/api/clear", axum::routing::post(clear_messages))
@@ -235,7 +235,7 @@ async fn send_ws_event(
         None => serde_json::json!({"type": event_type}),
     };
     socket
-        .send(Message::Text(payload.to_string()))
+        .send(Message::Text(payload.to_string().into()))
         .await
         .is_ok()
 }
@@ -247,7 +247,9 @@ async fn handle_ws(mut socket: WebSocket, state: AppState) {
     let count = state.store.count().await;
     let _ = socket
         .send(Message::Text(
-            serde_json::json!({"type": "init", "total": count}).to_string(),
+            serde_json::json!({"type": "init", "total": count})
+                .to_string()
+                .into(),
         ))
         .await;
 
@@ -278,7 +280,7 @@ async fn handle_ws(mut socket: WebSocket, state: AppState) {
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                         let _ = socket.send(Message::Text(
-                            serde_json::json!({"type": "lagged", "missed": n}).to_string()
+                            serde_json::json!({"type": "lagged", "missed": n}).to_string().into()
                         )).await;
                     }
                     Err(_) => break,


### PR DESCRIPTION
## Summary

- Bumps `axum` from 0.7 to 0.8 and `tower-http` from 0.5 to 0.6
- Updates route path syntax from `/:param` to `/{param}` (axum 0.8 breaking change) across all four parameterised routes in `src/web.rs`
- Updates three `Message::Text(...)` call sites where axum 0.8 changed the inner type from `String` to `Utf8Bytes` — fixed by appending `.into()`

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 55 unit tests + integration tests pass
- [x] REST API routes (`/api/messages/{id}`, `/api/messages/{id}/tags`, `/api/messages/{id}/tags/{tag}`, `/api/messages/{id}/bookmark`) resolve correctly
- [x] WebSocket `init`, `new_message`, `lagged` events serialize correctly

Closes #147

https://claude.ai/code/session_01SWqixCwoVwpV2tSgzZbdMk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWqixCwoVwpV2tSgzZbdMk)_