### PR TITLE
test(web): REST handler integration tests via axum oneshot (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 | Commit | Description |
 |--------|-------------|
 | [`1b9fb8f`](https://github.com/Pappet/harux/commit/1b9fb8f) | `fix(store):` handle non-ASCII needles in contains_ignore_ascii_case (#133) |
-| [`PLACEHOLDER`](https://github.com/Pappet/harux/commit/PLACEHOLDER) | `test(web):` REST handler integration tests via oneshot (#121) |
+| [`f2632ae`](https://github.com/Pappet/harux/commit/f2632ae) | `test(web):` REST handler integration tests via oneshot (#121) |
 
 #### 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **Keyboard accessibility for custom elements** — added `tabindex`, `role="button"`, and Enter/Space keyboard activation for segment headers, copy buttons, field value cells, and tagging elements.
 - **Keyboard accessibility for source chips** — added `tabindex="0"`, `role="button"`, and Enter/Space keyboard activation for source chips in the message list header, allowing filter toggling via keyboard navigation.
 
+### Added
+- **REST handler integration tests** — added `tests/web_api.rs` with 17 `axum::Router::oneshot` tests covering every HTTP route: `GET /api/messages` (empty + with data), `GET /api/messages/{id}` (found + 404), `GET /api/search` (match + no-match), `GET /api/stats` (field presence), `POST /api/clear` (store empties), `POST /api/messages/{id}/tags` (ok + bad-request), `DELETE /api/messages/{id}/tags/{tag}` (ok + 404), `POST /api/messages/{id}/bookmark` (toggles + 404), `GET /api/export` (MLLP framing verified), `GET /ws` (route registered, not 404/405). No real TCP socket required. (#121)
+
 ### Fixed
 - **MLLP frame extraction — O(n²) re-scan eliminated** — `extract_mllp_frame` restarted its end-sequence search from the beginning of the accumulated buffer on every partial read. For a 3 MB MDM payload arriving in 64 KB chunks (~47 reads), this produced ~70 MB of redundant scanning. Added a `scan_from` parameter; `handle_connection` tracks the high-water-mark position across reads and passes it in, so only newly received bytes are searched for `FS+CR`. A `scan_offset = accumulated.len().saturating_sub(1)` update after each incomplete read, reset to 0 after consuming a frame, ensures the 2-byte end sequence is never missed at a chunk boundary. Added a unit test verifying consistent results between incremental and full-scan modes. (#118)
 - **Accurate memory accounting in the store** — `MessageStore::insert` and the eviction loop previously measured message size using `raw.len()` only, ignoring the 2–3× overhead from parsed segment/field/component strings, descriptions, validation warnings, and dictionary metadata. Added `Hl7Message::estimated_bytes()` that sums all heap-allocated string content across every field of the parsed message. Both `insert` (accumulates `current_bytes`) and the eviction loop (`freed_bytes` per evicted message) now call this method, making the 512 MB size limit meaningful for MDM messages with Base64-encoded attachments. (#131)
@@ -63,6 +66,7 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 | Commit | Description |
 |--------|-------------|
 | [`1b9fb8f`](https://github.com/Pappet/harux/commit/1b9fb8f) | `fix(store):` handle non-ASCII needles in contains_ignore_ascii_case (#133) |
+| [`PLACEHOLDER`](https://github.com/Pappet/harux/commit/PLACEHOLDER) | `test(web):` REST handler integration tests via oneshot (#121) |
 
 #### 2026-05-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,7 @@ mime_guess = "2"
 anyhow = "1"
 tracing-appender = "0.2.4"
 encoding_rs = "0.8.35"
+
+[dev-dependencies]
+tower = { version = "0.4", features = ["util"] }
+http-body-util = "0.1"

--- a/tests/web_api.rs
+++ b/tests/web_api.rs
@@ -1,0 +1,411 @@
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use harux::config::StoreConfig;
+use harux::hl7::types::Hl7Message;
+use harux::mllp::MllpStats;
+use harux::store::MessageStore;
+use harux::web::{create_router, AppState};
+use tower::ServiceExt;
+
+fn make_state() -> AppState {
+    AppState {
+        store: MessageStore::new(StoreConfig {
+            max_messages: 1000,
+            max_memory_mb: 10,
+        }),
+        stats: MllpStats::new(),
+        mllp_port: 2575,
+        max_connections: 10,
+    }
+}
+
+fn simple_raw() -> String {
+    "MSH|^~\\&|TEST|FAC|RECV|RFAC|20240101000000||ADT^A01|MSG001|P|2.5\r".to_string()
+}
+
+async fn collect_body(body: Body) -> axum::body::Bytes {
+    axum::body::to_bytes(body, usize::MAX).await.unwrap()
+}
+
+// ── GET /api/messages ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_messages_empty_returns_empty_array() {
+    let app = create_router(make_state());
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/messages")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = collect_body(res.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json, serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn list_messages_returns_one_summary() {
+    let state = make_state();
+    let mut msg = Hl7Message::new_empty(simple_raw(), "127.0.0.1".to_string());
+    msg.id = "list-test".to_string();
+    state.store.insert(msg).await;
+
+    let app = create_router(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/messages")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = collect_body(res.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json.as_array().unwrap().len(), 1);
+    assert_eq!(json[0]["id"], "list-test");
+}
+
+// ── GET /api/messages/{id} ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_message_known_id_returns_200() {
+    let state = make_state();
+    let mut msg = Hl7Message::new_empty(simple_raw(), "127.0.0.1".to_string());
+    msg.id = "known".to_string();
+    state.store.insert(msg).await;
+
+    let app = create_router(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/messages/known")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = collect_body(res.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["id"], "known");
+}
+
+#[tokio::test]
+async fn get_message_unknown_id_returns_404() {
+    let app = create_router(make_state());
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/messages/no-such-id")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+// ── GET /api/search ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn search_returns_matching_message() {
+    let state = make_state();
+    let mut msg = Hl7Message::new_empty(simple_raw(), "127.0.0.1".to_string());
+    msg.id = "srch-1".to_string();
+    msg.message_type = "ADT^A01".to_string();
+    state.store.insert(msg).await;
+
+    let app = create_router(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/search?q=ADT%5EA01")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = collect_body(res.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json.as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn search_returns_empty_for_no_match() {
+    let state = make_state();
+    let mut msg = Hl7Message::new_empty(simple_raw(), "127.0.0.1".to_string());
+    msg.id = "srch-2".to_string();
+    msg.message_type = "ADT^A01".to_string();
+    state.store.insert(msg).await;
+
+    let app = create_router(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/search?q=NOMATCH_XYZ")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = collect_body(res.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json.as_array().unwrap().len(), 0);
+}
+
+// ── GET /api/stats ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_stats_returns_expected_fields() {
+    let app = create_router(make_state());
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = collect_body(res.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json.get("total_messages").is_some());
+    assert!(json.get("received").is_some());
+    assert!(json.get("parsed_ok").is_some());
+    assert!(json.get("parse_errors").is_some());
+    assert!(json.get("mllp_port").is_some());
+    assert_eq!(json["mllp_port"], 2575);
+}
+
+// ── POST /api/clear ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn clear_empties_the_store() {
+    let state = make_state();
+    let mut msg = Hl7Message::new_empty(simple_raw(), "127.0.0.1".to_string());
+    msg.id = "to-clear".to_string();
+    state.store.insert(msg).await;
+    assert_eq!(state.store.count().await, 1);
+
+    let app = create_router(state.clone());
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/clear")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(state.store.count().await, 0);
+}
+
+// ── POST /api/messages/{id}/tags ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn add_tag_returns_ok() {
+    let state = make_state();
+    let mut msg = Hl7Message::new_empty(simple_raw(), "127.0.0.1".to_string());
+    msg.id = "tag-test".to_string();
+    state.store.insert(msg).await;
+
+    let payload = serde_json::to_vec(&serde_json::json!({"tag": "urgent"})).unwrap();
+    let app = create_router(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/messages/tag-test/tags")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn add_empty_tag_returns_bad_request() {
+    let state = make_state();
+    let mut msg = Hl7Message::new_empty(simple_raw(), "127.0.0.1".to_string());
+    msg.id = "empty-tag".to_string();
+    state.store.insert(msg).await;
+
+    let payload = serde_json::to_vec(&serde_json::json!({"tag": ""})).unwrap();
+    let app = create_router(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/messages/empty-tag/tags")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+// ── DELETE /api/messages/{id}/tags/{tag} ──────────────────────────────────────
+
+#[tokio::test]
+async fn remove_tag_round_trip() {
+    let state = make_state();
+    let mut msg = Hl7Message::new_empty(simple_raw(), "127.0.0.1".to_string());
+    msg.id = "rmtag".to_string();
+    state.store.insert(msg).await;
+    state.store.add_tag("rmtag", "urgent".to_string()).await;
+
+    let app = create_router(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/api/messages/rmtag/tags/urgent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn remove_tag_unknown_message_returns_404() {
+    let app = create_router(make_state());
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/api/messages/no-such/tags/urgent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+// ── POST /api/messages/{id}/bookmark ─────────────────────────────────────────
+
+#[tokio::test]
+async fn bookmark_toggle_returns_bookmarked_true() {
+    let state = make_state();
+    let mut msg = Hl7Message::new_empty(simple_raw(), "127.0.0.1".to_string());
+    msg.id = "bm-on".to_string();
+    state.store.insert(msg).await;
+
+    let app = create_router(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/messages/bm-on/bookmark")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = collect_body(res.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["bookmarked"], true);
+}
+
+#[tokio::test]
+async fn bookmark_toggle_unknown_id_returns_404() {
+    let app = create_router(make_state());
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/messages/no-such/bookmark")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+// ── GET /api/export ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn export_starts_with_mllp_start_byte() {
+    let state = make_state();
+    let mut msg = Hl7Message::new_empty(simple_raw(), "127.0.0.1".to_string());
+    msg.id = "export-1".to_string();
+    state.store.insert(msg).await;
+
+    let app = create_router(state);
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/export")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = collect_body(res.into_body()).await;
+    assert!(!body.is_empty());
+    assert_eq!(body[0], 0x0B, "expected MLLP VT start byte");
+    assert_eq!(body[body.len() - 2], 0x1C, "expected MLLP FS end byte");
+    assert_eq!(body[body.len() - 1], 0x0D, "expected MLLP CR end byte");
+}
+
+#[tokio::test]
+async fn export_empty_store_returns_empty_body() {
+    let app = create_router(make_state());
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/export")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = collect_body(res.into_body()).await;
+    assert!(body.is_empty());
+}
+
+// ── GET /ws ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn ws_endpoint_is_registered() {
+    // oneshot cannot perform a real WebSocket upgrade (no underlying TCP connection).
+    // We verify the route is registered: the handler runs and returns a WS-specific
+    // response (not 404 "route missing" or 405 "method not allowed").
+    let app = create_router(make_state());
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri("/ws")
+                .header("connection", "upgrade")
+                .header("upgrade", "websocket")
+                .header("sec-websocket-version", "13")
+                .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(res.status(), StatusCode::NOT_FOUND);
+    assert_ne!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
+}


### PR DESCRIPTION
## Summary

Adds `tests/web_api.rs` — 17 handler-level integration tests using `axum::Router::oneshot` (no real TCP socket). Added `tower = "0.4"` and `http-body-util = "0.1"` as dev-dependencies.

## Routes covered

| Route | Tests |
|-------|-------|
| `GET /api/messages` | empty list → `[]`; one message → summary with correct ID |
| `GET /api/messages/{id}` | known ID → 200 + body; unknown → 404 |
| `GET /api/search` | matching message found; no-match returns `[]` |
| `GET /api/stats` | all expected fields present; `mllp_port` correct |
| `POST /api/clear` | store count drops to 0 |
| `POST /api/messages/{id}/tags` | valid tag → 200; empty tag → 400 |
| `DELETE /api/messages/{id}/tags/{tag}` | round-trip ok; unknown message → 404 |
| `POST /api/messages/{id}/bookmark` | toggles to `true`; unknown → 404 |
| `GET /api/export` | MLLP VT start byte + FS+CR end bytes verified; empty store → empty body |
| `GET /ws` | route is registered (not 404 / 405); upgrade itself needs real TCP |

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] 17/17 new integration tests pass
- [x] All 55 unit tests + 10 fixture tests + 1 benchmark still pass
- [x] CI green

Closes #121

https://claude.ai/code/session_01SWqixCwoVwpV2tSgzZbdMk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWqixCwoVwpV2tSgzZbdMk)_