### PR TITLE
docs: sync CLAUDE.md with code; drop unused tower-http + dead escJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **`MessageStore::search` — zero heap allocation per message per query** — the previous implementation called `.to_lowercase()` on six fields of every stored message on each search request (up to 60 000 short-lived `String`s for a full 10 000-message store). Replaced with `contains_ignore_ascii_case`, a window-scan that calls `eq_ignore_ascii_case` byte-by-byte with no allocation for ASCII needles. For non-ASCII needles the function falls back to `to_lowercase().contains()` so multi-byte code-point boundaries are never sliced. HL7 data is almost always ASCII, so the fast path is taken in practice. (#133)
 
 ### Changed
+- **Docs — `CLAUDE.md` brought back in sync with the code** — the guidance file had drifted from the implementation in several places that actively mislead contributors: the store section referenced removed `DEFAULT_CAPACITY`/`MAX_STORE_BYTES` constants (capacity is now config-driven via `StoreConfig`); the frontend was described as a single `app.js` ("Three files") despite the `state`/`util`/`ws`/`render`/`diff`/`app` split; the constraints table forbade "prepend logic" even though `prependMessagesToList` is the no-filter hot path; the Web API list omitted the tag/bookmark routes and several WS event types; and the Source Layout tree omitted `config.rs`, `dictionary.rs`, `validation.rs`, `lib.rs`, `hl7/message_types.rs`, the embedded `assets/`, and the Rust integration tests. All sections updated to match `src/` and `static/` as they exist today.
+- **Dependency cleanup — remove unused `tower-http`** — `tower-http` (with `cors` + `fs` features) was declared in `Cargo.toml` but had zero usages in `src/`; CORS is not configured and static files are served via `rust-embed`, not `tower-http::fs`. Removed the dependency to cut build time and avoid signalling capabilities the server does not actually use.
+- **Dead code removal — `escJS` helper** — `static/util.js` defined `escJS()` but nothing called it (inline `onclick=`/`on*=` handlers were replaced by `data-action` delegation in #137, which removed the only callers). Deleted the dead function.
 - **`SegmentDef::field_by_seq` — single shared lookup helper** — the O(1)-fast-path + O(N)-fallback field lookup pattern was duplicated verbatim in `dictionary.rs` (`get_field_description` and `inject_descriptions`) and `validation.rs` (`validate_data_types`). Extracted to `SegmentDef::field_by_seq(seq: usize) -> Option<&FieldDef>`. All three call sites replaced with a single method call. (#128)
 
 - **Syntax highlighting in Raw / ACK / JSON tabs** — segment names keep their accent colour and now sit alongside coloured HL7 delimiters. The 5 delimiters are auto-detected from MSH-1 / MSH-2, so non-standard separator characters are highlighted just as well as the spec defaults. When MSH is missing entirely (malformed payload) no delimiter colouring is applied — we don't pretend to know separators we never saw. The JSON tab now distinguishes keys, strings, numbers, booleans and `null` with dedicated colours; pretty-print whitespace is preserved and arbitrary string values are still safely HTML-escaped.
@@ -66,6 +69,12 @@ and this project follows [Semantic Versioning](https://semver.org/lang/en/).
 - **Performance — O(1) header counters, source-legend fast path, tick-row cutoff** — three more per-batch performance hotspots addressed: (1) `updateHeaderCounters` no longer iterates `state.messages[]` to compute validation/bookmark totals; two new incremental counters (`totalValidationCount`, `totalBookmarkCount`) are maintained in `state`, incremented in `addMessage`, adjusted ±1 in `updateMessageBookmark`, and recomputed in bulk only when `loadMessages` replaces the buffer. (2) `renderSourceLegend` takes a fast path when the sorted list of source labels is unchanged: it patches count spans and active/dimmed classes in-place without touching `innerHTML` or destroying any DOM nodes. (3) `tickRowRelativeTimes` skips immediately when `document.hidden` (tab not visible) and bails out per-row when the message timestamp is older than 5 minutes, since `rowTimeLabel` returns a static clock time beyond that threshold. (#173, #174, #175)
 
 ### Commit History (chronological)
+
+#### 2026-05-31
+
+| Commit | Description |
+|--------|-------------|
+| [`36caa17`](https://github.com/Pappet/harux/commit/36caa17fd408650e7e8eb717f4593e0670d96245) | `docs:` sync CLAUDE.md with code; drop unused tower-http + dead escJS |
 
 #### 2026-05-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,12 @@ Harux is an MLLP server with a real-time web UI for inspecting HL7 v2.x messages
 
 ### Store Capacity & Eviction
 
-- **Count limit:** `DEFAULT_CAPACITY = 10_000` messages (secondary safeguard)
-- **Size limit:** `MAX_STORE_BYTES = 512 MB` (primary safeguard)
-- **Trigger:** either limit hit → evict oldest 10% of messages
+Limits are **config-driven** via `StoreConfig` (`src/config.rs`), not hardcoded constants.
+
+- **Count limit:** `store.max_messages` (default `10_000`) — secondary safeguard
+- **Size limit:** `store.max_memory_mb` (default `512` MB) — primary safeguard
+- **Trigger:** either limit hit → background eviction task evicts oldest 10% of messages
+- **Bookmark protection:** bookmarked messages are skipped during eviction (popped and pushed back to the front in original order); see `run_eviction_loop` in `src/store.rs`
 - **Reason:** MDM messages with Base64-encoded attachments can be several MB each; count-only eviction is insufficient for real-world Orchestra traffic
 
 ### HL7 Parsing (`src/hl7/`)
@@ -84,34 +87,30 @@ Harux is an MLLP server with a real-time web UI for inspecting HL7 v2.x messages
 
 ### Web API Routes
 
-- `GET /api/messages?offset=&limit=` — Paginated message list (newest first)
+- `GET /api/messages?offset=&limit=` — Paginated message list (newest first; `limit` capped at 1000)
 - `GET /api/messages/{id}` — Full message with segments
-- `GET /api/search?q=&limit=` — Search messages (client-side in UI, server-side via this endpoint)
+- `GET /api/search?q=&limit=` — Search messages server-side. **Note:** the UI currently filters client-side (`matchesSearch()`); this endpoint exists but is not yet wired into the frontend.
 - `GET /api/stats` — Server statistics
+- `POST /api/messages/{id}/tags` — Add a tag (JSON body `{"tag": "..."}`)
+- `DELETE /api/messages/{id}/tags/{tag}` — Remove a tag
+- `POST /api/messages/{id}/bookmark` — Toggle bookmark
 - `POST /api/clear` — Clear all messages
 - `GET /api/export` — Download every stored message as one MLLP-framed `.hl7` file (raw payloads, oldest first, directly replayable)
-- `WS /ws` — Real-time updates ("init", "new_message", "lagged" events)
+- `WS /ws` — Real-time updates (`init`, `new_message`, `tags_updated`, `bookmark_toggled`, `cleared`, `lagged` events)
 
 ### Frontend (`static/`)
 
-Three files, all embedded into the binary at compile time via `rust-embed`:
-
-```
-static/
-├── index.html   # HTML structure only
-├── style.css    # All styles (dark theme, CSS variables)
-└── app.js       # All logic (WebSocket, rendering, search, batching)
-```
+The SPA is split across HTML, CSS, and several JS files (see the full tree in **Source Layout** below), all embedded into the binary at compile time via `rust-embed`. The JS files are plain `<script>` includes with **no module system** — they share a single global `state` object (`state.js`) and must be loaded in dependency order (`state` → `util` → `ws` → `render` → `diff` → `app`).
 
 **Important:** After any change to `static/`, a recompile is required — `rust-embed` bakes the files in at build time. There is no hot-reload.
 
 The frontend is **intentional vanilla JS — no framework**. Do not introduce React, Vue, Svelte, or any build toolchain. The embedded SPA approach is a deliberate architectural decision for zero-dependency deployment.
 
 Key frontend behaviors:
-- Messages are batched and rendered at most every 250ms (prevents DOM freeze at high message rates)
+- Messages are batched and flushed at most every 250ms (prevents DOM freeze at high message rates)
+- When no client-side filters are active, new messages are **prepended** to the list (`prependMessagesToList`); when a filter/search/bookmark filter is active, the list is fully rebuilt (`renderMessageList`)
 - ⏸ Pause/▶ Live button buffers incoming messages without displaying them
-- Search is purely client-side (filters `messages[]` array via `matchesSearch()`)
-- Search input is debounced 300ms as a safeguard for a future `/api/search` call
+- Search is client-side (filters `messages[]` array via `matchesSearch()`), debounced 300ms
 - Parse errors are shown with `⚠ PARSE ERROR` in red (`var(--error)`) in the message list
 
 ## Deployment Context
@@ -127,7 +126,7 @@ Key frontend behaviors:
 | Frontend | No framework, no build toolchain, no npm |
 | Parser | No zero-copy / lifetime refactoring (premature optimization) |
 | Store locking | No dashmap, no mpsc-channel refactor (planned for Milestone 1) |
-| DOM rendering | No prepend logic (batching at 250ms is sufficient) |
+| DOM rendering | Keep the 250ms flush batching. New messages prepend on the no-filter hot path; full rebuild only when a filter is active. Do not add per-message full rebuilds. |
 | Dependencies | Minimize new crates; check `Cargo.toml` before adding |
 
 ## Current Milestone: Milestone 3 — Message Analysis
@@ -145,13 +144,19 @@ Do not implement features from later milestones speculatively.
 ```
 src/
 ├── main.rs          # Entry point, tokio::select! over MLLP + Web tasks
-├── mllp.rs          # TCP listener, MLLP framing, ACK/NACK dispatch
+├── lib.rs           # Library crate root (re-exports modules for integration tests)
+├── config.rs        # TOML → env → defaults config loading (Config + typed sections)
+├── mllp.rs          # TCP listener, MLLP framing, charset decode, ACK/NACK dispatch
 ├── store.rs         # In-memory store with broadcast channel, dual eviction
 ├── web.rs           # Axum router, REST handlers, WebSocket handler
-└── hl7/
-    ├── mod.rs
-    ├── parser.rs    # Raw HL7 → Hl7Message, delimiter extraction, ACK builder
-    └── types.rs     # Hl7Message, Hl7MessageSummary, Hl7Segment, Hl7Field, Delimiters
+├── dictionary.rs    # Embedded HL7 field/segment dictionary (v2.5.1.json)
+├── validation.rs    # Required segment/field + primitive datatype validation
+├── hl7/
+│   ├── mod.rs
+│   ├── parser.rs        # Raw HL7 → Hl7Message, delimiter extraction, ACK builder
+│   ├── types.rs         # Hl7Message, Hl7MessageSummary, Hl7Segment, Hl7Field, Delimiters
+│   └── message_types.rs # Message-type registry (message_types.json)
+└── assets/hl7/      # Embedded JSON: v2.5.1.json (dictionary), message_types.json
 static/
 ├── index.html       # HTML skeleton
 ├── style.css        # Dark theme, CSS variables
@@ -160,10 +165,15 @@ static/
 ├── ws.js            # WebSocket + ingestion + stats polling
 ├── render.js        # List, legend, health pills, detail-panel tabs
 ├── diff.js          # Diff tab (renderDiffTab + builders)
-└── app.js           # Init + UI handlers (onclick) + splitter
+├── app.js           # Init + UI handlers (data-action delegation) + splitter
+└── fonts/           # Self-hosted woff2 (Inter, JetBrains Mono)
 tests/
-├── test.sh          # Linux/macOS functional + load test (netcat)
-└── test.ps1         # Windows functional + load test (.NET TcpClient, 1000 msg)
+├── parser_fixtures.rs            # Parser tests against tests/messages/*.hl7 fixtures
+├── web_api.rs                    # Axum REST/handler integration tests
+├── benchmark_concurrent_insert.rs # Concurrent store insert benchmark
+├── messages/                     # .hl7 fixtures (valid / errors / unknown_types)
+├── test.sh                       # Linux/macOS functional + load test (netcat)
+└── test.ps1                      # Windows functional + load test (.NET TcpClient, 1000 msg)
 ```
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,6 @@ dependencies = [
  "tokio",
  "toml",
  "tower 0.4.13",
- "tower-http",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -418,12 +417,6 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -1089,19 +1082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,31 +1151,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "http-range-header",
- "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "time", "
 
 # Web framework + WebSocket
 axum = { version = "0.8", features = ["ws"] }
-tower-http = { version = "0.6", features = ["cors", "fs"] }
 
 # Serialization
 serde = { version = "1", features = ["derive", "rc"] }

--- a/static/util.js
+++ b/static/util.js
@@ -126,15 +126,6 @@ function escAttr(str) {
         .replace(/>/g, '&gt;');
 }
 
-function escJS(str) {
-    if (!str) return '';
-    return str.replace(/\\/g, '\\\\')
-        .replace(/'/g, '\\\'')
-        .replace(/"/g, '\\"')
-        .replace(/\n/g, '\\n')
-        .replace(/\r/g, '\\r');
-}
-
 // --- Toast + clipboard ---
 function showToast(message, type = 'error') {
     const toast = document.createElement('div');


### PR DESCRIPTION
## Summary

This is step 1 ("docs first") of a broader architecture-review follow-up: a behavior-neutral cleanup that realigns the contributor-facing documentation with the actual code and removes two pieces of confirmed dead weight.

### `CLAUDE.md` corrections (the file had drifted from the implementation)

| Section | Was | Now |
|---|---|---|
| Store Capacity & Eviction | Referenced removed consts `DEFAULT_CAPACITY` / `MAX_STORE_BYTES` | Documents config-driven `StoreConfig` (`max_messages`, `max_memory_mb`) + bookmark-protection during eviction |
| Frontend | "Three files … `app.js` (All logic)" | Documents the real `state`/`util`/`ws`/`render`/`diff`/`app` split + mandatory load order |
| Constraints table | "DOM rendering — **No prepend logic**" | Reflects that `prependMessagesToList` *is* the no-filter hot path; full rebuild only when a filter is active |
| Web API Routes | Missing tag/bookmark routes; partial WS event list | Adds `POST/DELETE …/tags`, `POST …/bookmark`; full WS event list (`tags_updated`, `bookmark_toggled`, `cleared`); notes `/api/search` is not yet wired into the UI |
| Source Layout | Omitted `config.rs`, `dictionary.rs`, `validation.rs`, `lib.rs`, `hl7/message_types.rs`, `assets/`, Rust integration tests | Complete tree |

### Dead code / dependency removal
- **`tower-http`** removed from `Cargo.toml` — declared with `cors` + `fs` features but **zero usages** in `src/` (CORS isn't configured; static files are served via `rust-embed`). Cuts build time.
- **`escJS()`** removed from `static/util.js` — no callers since `data-action` delegation (#137) replaced the inline `on*=` handlers that used it.

## Why this matters

`CLAUDE.md` is the first thing a new contributor (human or agent) is told to trust. Each drift above actively misleads — e.g. it forbade prepend logic that is in fact the rendering hot path, and described a single-file frontend that was split long ago.

## Verification
- `cargo build` ✅
- `cargo clippy -- -D warnings` ✅ (clean)
- `cargo test` ✅ (all suites pass, incl. 17 `web_api` integration tests)
- `cargo fmt --check` ✅

No functional changes.

https://claude.ai/code/session_01BFUQYph4cTw1N5Lxsjf6UP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFUQYph4cTw1N5Lxsjf6UP)_